### PR TITLE
fix: ensure unique hostnames on multi node chains

### DIFF
--- a/framework/docker/chain_node.go
+++ b/framework/docker/chain_node.go
@@ -80,6 +80,10 @@ func (tn *ChainNode) GetInternalHostName(ctx context.Context) (string, error) {
 	return tn.HostName(), nil
 }
 
+func (tn *ChainNode) HostName() string {
+	return CondenseHostName(tn.Name())
+}
+
 func (tn *ChainNode) GetRPCClient() (rpcclient.Client, error) {
 	return tn.Client, nil
 }

--- a/framework/docker/chain_node_test.go
+++ b/framework/docker/chain_node_test.go
@@ -1,0 +1,44 @@
+package docker
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+)
+
+func TestChainNodeHostName(t *testing.T) {
+	// Create a chain with multiple nodes
+	testName := "test-hostname"
+	chainID := "test-chain"
+	logger := zaptest.NewLogger(t)
+
+	// Create nodes with different indices
+	node1 := NewDockerChainNode(logger, true, Config{
+		ChainConfig: &ChainConfig{
+			ChainID: chainID,
+		},
+	}, testName, DockerImage{}, 0)
+
+	node2 := NewDockerChainNode(logger, true, Config{
+		ChainConfig: &ChainConfig{
+			ChainID: chainID,
+		},
+	}, testName, DockerImage{}, 1)
+
+	node3 := NewDockerChainNode(logger, false, Config{
+		ChainConfig: &ChainConfig{
+			ChainID: chainID,
+		},
+	}, testName, DockerImage{}, 2)
+
+	// Get hostnames
+	hostname1 := node1.HostName()
+	hostname2 := node2.HostName()
+	hostname3 := node3.HostName()
+
+	// verify that all hostnames are different
+	require.NotEqual(t, hostname1, hostname2)
+	require.NotEqual(t, hostname1, hostname3)
+	require.NotEqual(t, hostname2, hostname3)
+}

--- a/framework/docker/da_node.go
+++ b/framework/docker/da_node.go
@@ -126,6 +126,16 @@ func (n *DANode) Start(ctx context.Context, opts ...types.DANodeStartOption) err
 	return nil
 }
 
+// Name of the test node container.
+func (n *node) Name() string {
+	return fmt.Sprintf("%s-%s", n.GetType(), SanitizeContainerName(n.TestName))
+}
+
+// HostName of the test node container.
+func (n *node) HostName() string {
+	return CondenseHostName(n.Name())
+}
+
 // modifyConfigToml disables RPC authentication so that the tests can use the endpoints without configuring auth.
 func (n *DANode) modifyConfigToml(ctx context.Context) error {
 	modifications := make(toml.Toml)

--- a/framework/docker/docker_node.go
+++ b/framework/docker/docker_node.go
@@ -62,16 +62,6 @@ func (n *node) GetType() string {
 	return n.nodeType
 }
 
-// Name of the test node container.
-func (n *node) Name() string {
-	return fmt.Sprintf("%s-%s", n.GetType(), SanitizeContainerName(n.TestName))
-}
-
-// HostName of the test node container.
-func (n *node) HostName() string {
-	return CondenseHostName(n.Name())
-}
-
 // RemoveContainer gracefully stops and removes the container associated with the node using the provided context.
 func (n *node) RemoveContainer(ctx context.Context) error {
 	return n.containerLifecycle.RemoveContainer(ctx)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

the embedded `HostName` function was being called which was not including an index resulting in multiple host names being the same. This PR fixes this and adds a unit test.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
