### PR TITLE
feat: Enhance broadcaster logging

### DIFF
--- a/framework/docker/broadcaster.go
+++ b/framework/docker/broadcaster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/celestiaorg/tastora/framework/types"
 	sdktx "github.com/cosmos/cosmos-sdk/client/tx"
 	"path"
+	"reflect"
 	"testing"
 	"time"
 
@@ -275,7 +276,8 @@ func (b *broadcaster) BroadcastMessages(ctx context.Context, signingWallet types
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}
-	b.t.Logf("broadcasted tx hash: %s", respWithTxHash.TxHash)
+	msgType := reflect.TypeOf(msgs[0]).Elem().Name()
+	b.t.Logf("broadcasted msg from wallet address %s; message type: %s; tx hash: %s", signingWallet.GetFormattedAddress(), msgType, respWithTxHash.TxHash)
 
 	return getFullyPopulatedResponse(ctx, cc, respWithTxHash.TxHash)
 }

--- a/framework/docker/broadcaster.go
+++ b/framework/docker/broadcaster.go
@@ -276,8 +276,12 @@ func (b *broadcaster) BroadcastMessages(ctx context.Context, signingWallet types
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}
-	msgType := reflect.TypeOf(msgs[0]).Elem().Name()
-	b.t.Logf("broadcasted msg from wallet address %s; message type: %s; tx hash: %s", signingWallet.GetFormattedAddress(), msgType, respWithTxHash.TxHash)
+	var msgTypes []string
+	for _, msg := range msgs {
+		msgType := reflect.TypeOf(msg).Elem().Name()
+		msgTypes = append(msgTypes, msgType)
+	}
+	b.t.Logf("broadcasted msg from wallet address %s; message types: %s; tx hash: %s", signingWallet.GetFormattedAddress(), msgTypes, respWithTxHash.TxHash)
 
 	return getFullyPopulatedResponse(ctx, cc, respWithTxHash.TxHash)
 }


### PR DESCRIPTION
Currently, the broadcaster logs a hash, this is not that useful. It would be better to include information about what message type was broadcast, and potentially information about the wallet that broadcast it. E.g. key name or address.

Closes: #29  