### PR TITLE
feat: add ability to arbitrarily modify config files on DA nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## Run unit tests
-	@go test -cover -timeout=30m -parallel=4 ./...
+	@go test -cover -timeout=30m ./...
 .PHONY: test
 
 # Runs linters without modifying files

--- a/framework/docker/create_wallet_test.go
+++ b/framework/docker/create_wallet_test.go
@@ -8,7 +8,6 @@ import (
 
 // TestCreateAndFundWallet tests wallet creation and funding.
 func (s *DockerTestSuite) TestCreateAndFundWallet() {
-	s.T().Parallel()
 	amount := math.NewInt(1000000)
 	sendAmount := sdk.NewCoins(sdk.NewCoin("utia", amount))
 	testWallet, err := wallet.CreateAndFund(s.ctx, "test", sendAmount, s.chain)

--- a/framework/docker/da_network_test.go
+++ b/framework/docker/da_network_test.go
@@ -102,7 +102,10 @@ func (s *DockerTestSuite) TestDANetworkCreation() {
 	})
 }
 
-// TestDANetworkCreation tests the creation of a DataAvailabilityNetwork with one of each type of node.
+// TestModifyConfigFileDANetwork ensures modification of config files is possible by
+// - disabling auth at startup
+// - enabling auth and making sure it is not possible to query RPC
+// - disabling auth again and verifying it is possible to query RPC
 func (s *DockerTestSuite) TestModifyConfigFileDANetwork() {
 	if testing.Short() {
 		s.T().Skip("skipping due to short mode")

--- a/framework/docker/da_network_test.go
+++ b/framework/docker/da_network_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"github.com/celestiaorg/tastora/framework/testutil/toml"
 	"github.com/celestiaorg/tastora/framework/types"
 	"testing"
 )
@@ -99,4 +100,85 @@ func (s *DockerTestSuite) TestDANetworkCreation() {
 		)
 		s.Require().NoError(err)
 	})
+}
+
+// TestDANetworkCreation tests the creation of a DataAvailabilityNetwork with one of each type of node.
+func (s *DockerTestSuite) TestModifyConfigFileDANetwork() {
+	if testing.Short() {
+		s.T().Skip("skipping due to short mode")
+	}
+	s.T().Parallel()
+
+	ctx := context.Background()
+	var bridgeNodes []types.DANode
+
+	// default configuration uses 1/1/1 for Bridge/Light/Full da nodes.
+	daNetwork, err := s.provider.GetDataAvailabilityNetwork(ctx)
+	s.Require().NoError(err)
+
+	s.T().Run("da nodes can be created", func(t *testing.T) {
+		bridgeNodes = daNetwork.GetBridgeNodes()
+		s.Require().Len(bridgeNodes, 1)
+	})
+
+	genesisHash := s.getGenesisHash(ctx)
+
+	hostname, err := s.chain.GetNodes()[0].GetInternalHostName(ctx)
+	s.Require().NoError(err, "failed to get internal hostname")
+
+	bridgeNode := bridgeNodes[0]
+
+	chainID := s.chain.cfg.ChainConfig.ChainID
+
+	s.T().Run("bridge node can be started", func(t *testing.T) {
+		err = bridgeNode.Start(ctx,
+			types.WithChainID(chainID),
+			types.WithAdditionalStartArguments("--p2p.network", chainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"),
+			types.WithEnvironmentVariables(
+				map[string]string{
+					"CELESTIA_CUSTOM": types.BuildCelestiaCustomEnvVar(chainID, genesisHash, ""),
+					"P2P_NETWORK":     chainID,
+				},
+			),
+		)
+		s.Require().NoError(err)
+	})
+
+	s.T().Run("bridge node config changed", func(t *testing.T) {
+		s.setAuth(ctx, bridgeNode, true)
+	})
+
+	s.T().Run("bridge node rpc in-accessible", func(t *testing.T) {
+		_, err := bridgeNode.GetP2PInfo(ctx)
+		s.Require().Error(err, "was able to get bridge node p2p info after auth was enabled")
+	})
+
+	s.T().Run("bridge node config changed back", func(t *testing.T) {
+		s.setAuth(ctx, bridgeNode, false)
+	})
+
+	s.T().Run("bridge node rpc accessible again", func(t *testing.T) {
+		_, err := bridgeNode.GetP2PInfo(ctx)
+		s.Require().NoError(err, "failed to get bridge node p2p info")
+	})
+}
+
+// setAuth modifies the node's configuration to enable or disable authentication and restarts the node to apply changes.
+func (s *DockerTestSuite) setAuth(ctx context.Context, daNode types.DANode, auth bool) {
+	modifications := map[string]toml.Toml{
+		"config.toml": {
+			"RPC": toml.Toml{
+				"SkipAuth": !auth,
+			},
+		},
+	}
+
+	err := daNode.Stop(ctx)
+	s.Require().NoErrorf(err, "failed to stop %s node", daNode.GetType().String())
+
+	err = daNode.ModifyConfigFiles(ctx, modifications)
+	s.Require().NoError(err, "failed to modify config files")
+
+	err = daNode.Start(ctx)
+	s.Require().NoErrorf(err, "failed to re-start %s node", daNode.GetType().String())
 }

--- a/framework/docker/da_network_test.go
+++ b/framework/docker/da_network_test.go
@@ -12,7 +12,6 @@ func (s *DockerTestSuite) TestDANetworkCreation() {
 	if testing.Short() {
 		s.T().Skip("skipping due to short mode")
 	}
-	s.T().Parallel()
 
 	ctx := context.Background()
 	var (
@@ -110,8 +109,6 @@ func (s *DockerTestSuite) TestModifyConfigFileDANetwork() {
 	if testing.Short() {
 		s.T().Skip("skipping due to short mode")
 	}
-	s.T().Parallel()
-
 	ctx := context.Background()
 	var bridgeNodes []types.DANode
 

--- a/framework/docker/docker_node.go
+++ b/framework/docker/docker_node.go
@@ -75,7 +75,7 @@ func (n *node) stopContainer(ctx context.Context) error {
 	return n.containerLifecycle.StopContainer(ctx)
 }
 
-// stopContainer starts the container associated with the node using the provided context.
+// startContainer starts the container associated with the node using the provided context.
 func (n *node) startContainer(ctx context.Context) error {
 	return n.containerLifecycle.StartContainer(ctx)
 }

--- a/framework/docker/docker_node.go
+++ b/framework/docker/docker_node.go
@@ -69,3 +69,13 @@ func (n *node) GetType() string {
 func (n *node) removeContainer(ctx context.Context) error {
 	return n.containerLifecycle.RemoveContainer(ctx)
 }
+
+// stopContainer gracefully stops the container associated with the node using the provided context.
+func (n *node) stopContainer(ctx context.Context) error {
+	return n.containerLifecycle.StopContainer(ctx)
+}
+
+// stopContainer starts the container associated with the node using the provided context.
+func (n *node) startContainer(ctx context.Context) error {
+	return n.containerLifecycle.StartContainer(ctx)
+}

--- a/framework/docker/docker_test.go
+++ b/framework/docker/docker_test.go
@@ -40,6 +40,10 @@ func (s *DockerTestSuite) SetupSuite() {
 
 	s.logger = zaptest.NewLogger(s.T())
 	s.encConfig = testutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{})
+}
+
+func (s *DockerTestSuite) SetupTest() {
+	s.dockerClient, s.networkID = DockerSetup(s.T())
 
 	s.provider = s.createDefaultProvider()
 	chain, err := s.provider.GetChain(s.ctx)
@@ -48,17 +52,10 @@ func (s *DockerTestSuite) SetupSuite() {
 
 	err = s.chain.Start(s.ctx)
 	s.Require().NoError(err)
-
-	s.T().Cleanup(func() {
-		err := s.chain.Stop(s.ctx)
-		if err != nil {
-			s.T().Logf("Failed to stop chain: %s", err)
-		}
-	})
 }
 
-// TearDownSuite removes docker resources.
-func (s *DockerTestSuite) TearDownSuite() {
+// TearDownTest removes docker resources.
+func (s *DockerTestSuite) TearDownTest() {
 	DockerCleanup(s.T(), s.dockerClient)()
 }
 

--- a/framework/docker/upgrade_version_test.go
+++ b/framework/docker/upgrade_version_test.go
@@ -25,6 +25,6 @@ func (s *DockerTestSuite) TestUpgradeVersion() {
 
 	abciInfo, err := rpcClient.ABCIInfo(s.ctx)
 	s.Require().NoError(err, "failed to fetch ABCI info")
-	s.Require().Equal("4.0.0-rc6", abciInfo.Response.GetVersion(), "version mismatch")
+	s.Require().Equal("4.0.2-mocha", abciInfo.Response.GetVersion(), "version mismatch")
 	s.Require().Equal(uint64(4), abciInfo.Response.GetAppVersion(), "app_version mismatch")
 }

--- a/framework/docker/upgrade_version_test.go
+++ b/framework/docker/upgrade_version_test.go
@@ -9,7 +9,7 @@ func (s *DockerTestSuite) TestUpgradeVersion() {
 	err := s.chain.Stop(s.ctx)
 	s.Require().NoError(err)
 
-	s.chain.UpgradeVersion(s.ctx, "v4.0.0-rc6")
+	s.chain.UpgradeVersion(s.ctx, "v4.0.2-mocha")
 
 	err = s.chain.Start(s.ctx)
 	s.Require().NoError(err)

--- a/framework/types/da_node.go
+++ b/framework/types/da_node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/celestiaorg/tastora/framework/testutil/toml"
 	"regexp"
 )
 
@@ -76,10 +77,15 @@ type DANode interface {
 	GetType() DANodeType
 	// GetHeader returns a header at a specified height.
 	GetHeader(ctx context.Context, height uint64) (Header, error)
+	// GetAllBlobs retrieves all blobs at the specified block height filtered by the provided namespaces.
 	GetAllBlobs(ctx context.Context, height uint64, namespaces []share.Namespace) ([]Blob, error)
 	// GetHostRPCAddress returns the externally resolvable RPC address of the node.
 	GetHostRPCAddress() string
+	// GetP2PInfo retrieves peer-to-peer network information including the PeerID and network addresses for the node.
 	GetP2PInfo(ctx context.Context) (P2PInfo, error)
+	// ModifyConfigFiles modifies the specified config files with the provided TOML modifications.
+	// the keys are the relative paths to the config file to be modified.
+	ModifyConfigFiles(ctx context.Context, configModifications map[string]toml.Toml) error
 }
 
 type Blob struct {
@@ -101,6 +107,9 @@ type DANodeStartOptions struct {
 	// EnvironmentVariables specifies any environment variables that should be passed to the DANode
 	// e.g. the CELESTIA_CUSTOM environment variable.
 	EnvironmentVariables map[string]string
+	// ConfigModifications specifies modifications to be applied to config files.
+	// The map key is the file path, and the value is the TOML modifications to apply.
+	ConfigModifications map[string]toml.Toml
 }
 
 // WithAdditionalStartArguments sets the additional start arguments to be used.
@@ -121,5 +130,12 @@ func WithEnvironmentVariables(envVars map[string]string) DANodeStartOption {
 func WithChainID(chainID string) DANodeStartOption {
 	return func(o *DANodeStartOptions) {
 		o.ChainID = chainID
+	}
+}
+
+// WithConfigModifications sets the config modifications to be applied to config files.
+func WithConfigModifications(configModifications map[string]toml.Toml) DANodeStartOption {
+	return func(o *DANodeStartOptions) {
+		o.ConfigModifications = configModifications
 	}
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR adds a new interface function to enable the modification of config files in the DANode containers. Both at startup and after the fact.

A test was added to test both use cases.

closes #28

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
