### PR TITLE
feat: add support for configuring chain nodes with distinct options

### DIFF
--- a/framework/docker/config.go
+++ b/framework/docker/config.go
@@ -22,9 +22,9 @@ type Config struct {
 
 type ChainConfig struct {
 	// Chain type, e.g. cosmos.
-	Type string `yaml:"type"`
+	Type string
 	// Chain name, e.g. cosmoshub.
-	Name string `yaml:"name"`
+	Name string
 	// Version of the docker image to use.
 	// Must be set.
 	Version string
@@ -50,8 +50,6 @@ type ChainConfig struct {
 	Gas string
 	// Trusting period of the chain.
 	TrustingPeriod string
-	// Do not use docker host mount.
-	NoHostMount bool
 	// When provided, genesis file contents will be altered before sharing for genesis.
 	ModifyGenesis func(Config, []byte) ([]byte, error)
 	// Override config parameters for files at filepath.
@@ -60,12 +58,21 @@ type ChainConfig struct {
 	EncodingConfig *testutil.TestEncodingConfig
 	// To avoid port binding conflicts, ports are only exposed on the 0th validator.
 	HostPortOverride map[int]int
-	// ExposeAdditionalPorts exposes each port id to the host on a random port. ex: "8080/tcp"
-	// Access the address with ChainNode.GetHostAddress
-	ExposeAdditionalPorts []string
 	// Additional start command arguments
 	AdditionalStartArgs []string
 	// Environment variables for chain nodes
+	Env []string
+	// NodeConfigs allows per-node configuration overrides, keyed by node index
+	NodeConfigs map[int]*ChainNodeConfig
+}
+
+// ChainNodeConfig provides per-node configuration that can override ChainConfig defaults
+type ChainNodeConfig struct {
+	// AdditionalStartArgs overrides the chain-level AdditionalStartArgs for this specific node
+	AdditionalStartArgs []string
+	// Image overrides the chain-level Images[0] for this specific node
+	Image *DockerImage
+	// Env overrides the chain-level Env for this specific node
 	Env []string
 }
 
@@ -81,6 +88,8 @@ type DataAvailabilityNetworkConfig struct {
 	Image DockerImage
 }
 
+// RollkitChainConfig defines the configuration for a Rollkit-based chain
+// including node counts, image settings, and chainID.
 type RollkitChainConfig struct {
 	// ChainID, e.g. test-rollkit
 	ChainID string

--- a/framework/docker/config.go
+++ b/framework/docker/config.go
@@ -62,8 +62,8 @@ type ChainConfig struct {
 	AdditionalStartArgs []string
 	// Environment variables for chain nodes
 	Env []string
-	// NodeConfigs allows per-node configuration overrides, keyed by node index
-	NodeConfigs map[int]*ChainNodeConfig
+	// ChainNodeConfigs allows per-node configuration overrides, keyed by node index
+	ChainNodeConfigs map[int]*ChainNodeConfig
 }
 
 // ChainNodeConfig provides per-node configuration that can override ChainConfig defaults

--- a/framework/docker/create_wallet_test.go
+++ b/framework/docker/create_wallet_test.go
@@ -8,8 +8,13 @@ import (
 
 // TestCreateAndFundWallet tests wallet creation and funding.
 func (s *DockerTestSuite) TestCreateAndFundWallet() {
-	s.SetupDockerResources()
-	s.StartChain()
+	var err error
+	s.provider = s.CreateDockerProvider()
+	s.chain, err = s.provider.GetChain(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(s.ctx)
+	s.Require().NoError(err)
 
 	amount := math.NewInt(1000000)
 	sendAmount := sdk.NewCoins(sdk.NewCoin("utia", amount))

--- a/framework/docker/create_wallet_test.go
+++ b/framework/docker/create_wallet_test.go
@@ -8,6 +8,9 @@ import (
 
 // TestCreateAndFundWallet tests wallet creation and funding.
 func (s *DockerTestSuite) TestCreateAndFundWallet() {
+	s.SetupDockerResources()
+	s.StartChain()
+
 	amount := math.NewInt(1000000)
 	sendAmount := sdk.NewCoins(sdk.NewCoin("utia", amount))
 	testWallet, err := wallet.CreateAndFund(s.ctx, "test", sendAmount, s.chain)

--- a/framework/docker/da_network_test.go
+++ b/framework/docker/da_network_test.go
@@ -121,6 +121,14 @@ func (s *DockerTestSuite) TestModifyConfigFileDANetwork() {
 	ctx := context.Background()
 	var bridgeNodes []types.DANode
 
+	var err error
+	s.provider = s.CreateDockerProvider()
+	s.chain, err = s.provider.GetChain(ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(ctx)
+	s.Require().NoError(err)
+
 	// default configuration uses 1/1/1 for Bridge/Light/Full da nodes.
 	daNetwork, err := s.provider.GetDataAvailabilityNetwork(ctx)
 	s.Require().NoError(err)

--- a/framework/docker/da_network_test.go
+++ b/framework/docker/da_network_test.go
@@ -53,7 +53,7 @@ func (s *DockerTestSuite) TestDANetworkCreation() {
 	fullNode := fullNodes[0]
 	lightNode := lightNodes[0]
 
-	chainID := "test"
+	chainID := s.chain.GetChainID()
 
 	s.T().Run("bridge node can be started", func(t *testing.T) {
 		err = bridgeNode.Start(ctx,
@@ -145,7 +145,7 @@ func (s *DockerTestSuite) TestModifyConfigFileDANetwork() {
 
 	bridgeNode := bridgeNodes[0]
 
-	chainID := "test"
+	chainID := s.chain.GetChainID()
 
 	s.T().Run("bridge node can be started", func(t *testing.T) {
 		err = bridgeNode.Start(ctx,

--- a/framework/docker/da_network_test.go
+++ b/framework/docker/da_network_test.go
@@ -14,6 +14,15 @@ func (s *DockerTestSuite) TestDANetworkCreation() {
 	}
 
 	ctx := context.Background()
+
+	var err error
+	s.provider = s.CreateDockerProvider()
+	s.chain, err = s.provider.GetChain(ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(ctx)
+	s.Require().NoError(err)
+
 	var (
 		bridgeNodes []types.DANode
 		lightNodes  []types.DANode
@@ -44,7 +53,7 @@ func (s *DockerTestSuite) TestDANetworkCreation() {
 	fullNode := fullNodes[0]
 	lightNode := lightNodes[0]
 
-	chainID := s.chain.cfg.ChainConfig.ChainID
+	chainID := "test"
 
 	s.T().Run("bridge node can be started", func(t *testing.T) {
 		err = bridgeNode.Start(ctx,
@@ -128,7 +137,7 @@ func (s *DockerTestSuite) TestModifyConfigFileDANetwork() {
 
 	bridgeNode := bridgeNodes[0]
 
-	chainID := s.chain.cfg.ChainConfig.ChainID
+	chainID := "test"
 
 	s.T().Run("bridge node can be started", func(t *testing.T) {
 		err = bridgeNode.Start(ctx,

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -105,6 +105,11 @@ func (c *Chain) GetFaucetWallet() types.Wallet {
 	return c.faucetWallet
 }
 
+// GetChainID returns the chain ID.
+func (c *Chain) GetChainID() string {
+	return c.cfg.ChainConfig.ChainID
+}
+
 // getBroadcaster returns a broadcaster that can broadcast messages to this chain.
 func (c *Chain) getBroadcaster() types.Broadcaster {
 	if c.broadcaster != nil {

--- a/framework/docker/docker_options.go
+++ b/framework/docker/docker_options.go
@@ -9,7 +9,7 @@ func WithPerNodeConfig(nodeConfigs map[int]*ChainNodeConfig) ConfigOption {
 		if cfg.ChainConfig == nil {
 			cfg.ChainConfig = &ChainConfig{}
 		}
-		cfg.ChainConfig.NodeConfigs = nodeConfigs
+		cfg.ChainConfig.ChainNodeConfigs = nodeConfigs
 	}
 }
 

--- a/framework/docker/docker_options.go
+++ b/framework/docker/docker_options.go
@@ -1,0 +1,44 @@
+package docker
+
+// ConfigOption is a function that modifies a Config
+type ConfigOption func(*Config)
+
+// WithPerNodeConfig adds per-node configuration to the chain config
+func WithPerNodeConfig(nodeConfigs map[int]*ChainNodeConfig) ConfigOption {
+	return func(cfg *Config) {
+		if cfg.ChainConfig == nil {
+			cfg.ChainConfig = &ChainConfig{}
+		}
+		cfg.ChainConfig.NodeConfigs = nodeConfigs
+	}
+}
+
+// WithNumValidators sets the number of validators to start the chain with.
+func WithNumValidators(numValidators int) ConfigOption {
+	return func(cfg *Config) {
+		if cfg.ChainConfig == nil {
+			cfg.ChainConfig = &ChainConfig{}
+		}
+		cfg.ChainConfig.NumValidators = &numValidators
+	}
+}
+
+// WithChainImage sets the default chain image
+func WithChainImage(image DockerImage) ConfigOption {
+	return func(cfg *Config) {
+		if cfg.ChainConfig == nil {
+			cfg.ChainConfig = &ChainConfig{}
+		}
+		cfg.ChainConfig.Images = []DockerImage{image}
+	}
+}
+
+// WithAdditionalStartArgs sets chain-level additional start arguments
+func WithAdditionalStartArgs(args ...string) ConfigOption {
+	return func(cfg *Config) {
+		if cfg.ChainConfig == nil {
+			cfg.ChainConfig = &ChainConfig{}
+		}
+		cfg.ChainConfig.AdditionalStartArgs = args
+	}
+}

--- a/framework/docker/rollkit_test.go
+++ b/framework/docker/rollkit_test.go
@@ -15,6 +15,10 @@ import (
 
 func (s *DockerTestSuite) TestRollkit() {
 	ctx := context.Background()
+
+	s.SetupDockerResources()
+	s.StartChain()
+
 	daNetwork, err := s.provider.GetDataAvailabilityNetwork(ctx)
 	s.Require().NoError(err)
 

--- a/framework/docker/rollkit_test.go
+++ b/framework/docker/rollkit_test.go
@@ -16,8 +16,13 @@ import (
 func (s *DockerTestSuite) TestRollkit() {
 	ctx := context.Background()
 
-	s.SetupDockerResources()
-	s.StartChain()
+	var err error
+	s.provider = s.CreateDockerProvider()
+	s.chain, err = s.provider.GetChain(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(s.ctx)
+	s.Require().NoError(err)
 
 	daNetwork, err := s.provider.GetDataAvailabilityNetwork(ctx)
 	s.Require().NoError(err)
@@ -28,7 +33,7 @@ func (s *DockerTestSuite) TestRollkit() {
 	s.Require().NoError(err, "failed to get internal hostname")
 
 	bridgeNode := daNetwork.GetBridgeNodes()[0]
-	chainID := s.chain.cfg.ChainConfig.ChainID
+	chainID := "test"
 
 	s.T().Run("bridge node can be started", func(t *testing.T) {
 		err = bridgeNode.Start(ctx,

--- a/framework/docker/rollkit_test.go
+++ b/framework/docker/rollkit_test.go
@@ -33,7 +33,7 @@ func (s *DockerTestSuite) TestRollkit() {
 	s.Require().NoError(err, "failed to get internal hostname")
 
 	bridgeNode := daNetwork.GetBridgeNodes()[0]
-	chainID := "test"
+	chainID := s.chain.GetChainID()
 
 	s.T().Run("bridge node can be started", func(t *testing.T) {
 		err = bridgeNode.Start(ctx,

--- a/framework/docker/upgrade_version_test.go
+++ b/framework/docker/upgrade_version_test.go
@@ -6,7 +6,17 @@ import (
 
 // TestUpgradeVersion verifies that you can upgrade from one tag to another.
 func (s *DockerTestSuite) TestUpgradeVersion() {
-	err := s.chain.Stop(s.ctx)
+	var err error
+	s.provider = s.CreateDockerProvider()
+	s.chain, err = s.provider.GetChain(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(s.ctx)
+	s.Require().NoError(err)
+
+	s.Require().NoError(wait.ForBlocks(s.ctx, 5, s.chain))
+
+	err = s.chain.Stop(s.ctx)
 	s.Require().NoError(err)
 
 	s.chain.UpgradeVersion(s.ctx, "v4.0.2-mocha")

--- a/framework/types/chain.go
+++ b/framework/types/chain.go
@@ -34,6 +34,8 @@ type Chain interface {
 	UpgradeVersion(ctx context.Context, version string)
 	// GetFaucetWallet returns the faucet wallet.
 	GetFaucetWallet() Wallet
+	// GetChainID returns the chain ID.
+	GetChainID() string
 }
 
 type ChainNode interface {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Enables the ability to configure chain nodes with different images/start options from one another.

closes #40

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
