### PR TITLE
feat: add dockerKeyring and GetKeyring function to chain node

### DIFF
--- a/framework/docker/broadcaster.go
+++ b/framework/docker/broadcaster.go
@@ -108,12 +108,8 @@ func (b *broadcaster) GetClientContext(ctx context.Context, wallet types.Wallet)
 
 	_, ok := b.keyrings[wallet]
 	if !ok {
-		localDir := b.t.TempDir()
 		containerKeyringDir := path.Join(cn.homeDir, "keyring-test")
-		kr, err := dockerinternal.NewLocalKeyringFromDockerContainer(ctx, cn.DockerClient, localDir, containerKeyringDir, cn.containerLifecycle.ContainerID())
-		if err != nil {
-			return client.Context{}, err
-		}
+		kr := dockerinternal.NewDockerKeyring(cn.DockerClient, cn.containerLifecycle.ContainerID(), containerKeyringDir, cn.cfg.ChainConfig.EncodingConfig.Codec)
 		b.keyrings[wallet] = kr
 	}
 

--- a/framework/docker/chain_node.go
+++ b/framework/docker/chain_node.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	dockerinternal "github.com/celestiaorg/tastora/framework/docker/internal"
 	"github.com/celestiaorg/tastora/framework/testutil/toml"
 	"github.com/celestiaorg/tastora/framework/types"
 	tmjson "github.com/cometbft/cometbft/libs/json"
@@ -87,6 +88,13 @@ func (tn *ChainNode) GetType() string {
 
 func (tn *ChainNode) GetRPCClient() (rpcclient.Client, error) {
 	return tn.Client, nil
+}
+
+// GetKeyring retrieves the keyring instance for the ChainNode. The keyring will be usable
+// by the host running the test.
+func (tn *ChainNode) GetKeyring() (keyring.Keyring, error) {
+	containerKeyringDir := path.Join(tn.homeDir, "keyring-test")
+	return dockerinternal.NewDockerKeyring(tn.DockerClient, tn.containerLifecycle.ContainerID(), containerKeyringDir, tn.cfg.ChainConfig.EncodingConfig.Codec), nil
 }
 
 func NewDockerChainNode(log *zap.Logger, validator bool, cfg Config, testName string, image DockerImage, index int) *ChainNode {

--- a/framework/docker/internal/docker_keyring.go
+++ b/framework/docker/internal/docker_keyring.go
@@ -12,15 +12,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/moby/client"
-	"io"
-	"path"
+	"os"
 	"path/filepath"
 	"sync"
-	"time"
 )
 
 var _ keyring.Keyring = &dockerKeyring{}
 
+// dockerKeyring implements the keyring.Keyring interface by lazy loading from the provided docker container.
+// Any writes to the keyring are also propagated to the container filesystem.
 type dockerKeyring struct {
 	mu                  sync.RWMutex
 	dockerClient        *client.Client
@@ -28,12 +28,12 @@ type dockerKeyring struct {
 	containerKeyringDir string
 	cdc                 codec.Codec
 
-	// Lazy-loaded keyring from container
+	// lazy-loaded keyring from container
 	localKeyring keyring.Keyring
 	tempDir      string
 }
 
-// NewDockerKeyring creates a new keyring that proxies to Docker container keys
+// NewDockerKeyring creates a new dockerKeyring instance.
 func NewDockerKeyring(dockerClient *client.Client, containerID, containerKeyringDir string, cdc codec.Codec) keyring.Keyring {
 	return &dockerKeyring{
 		dockerClient:        dockerClient,
@@ -43,8 +43,8 @@ func NewDockerKeyring(dockerClient *client.Client, containerID, containerKeyring
 	}
 }
 
-// ensureInitialized lazily loads the keyring from the Docker container into memory
-func (d *dockerKeyring) ensureInitialized(ctx context.Context) error {
+// ensureInitialized lazily loads the keyring from the Docker container a temp directory for testing.
+func (d *dockerKeyring) ensureInitialized() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -52,110 +52,102 @@ func (d *dockerKeyring) ensureInitialized(ctx context.Context) error {
 		return nil
 	}
 
-	kr := keyring.NewInMemory(d.cdc)
-
-	// copy the contents of the keyring directory from the docker container.
-	reader, _, err := d.dockerClient.CopyFromContainer(ctx, d.containerID, d.containerKeyringDir)
-	if err != nil {
-		return fmt.Errorf("failed to copy keyring from container: %w", err)
+	// create temp directory for keyring files
+	tempDir := filepath.Join(os.TempDir(), "docker-keyring-"+d.containerID)
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer reader.Close()
 
-	// Extract and parse keyring files
-	tr := tar.NewReader(reader)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read tar entry: %w", err)
-		}
+	d.tempDir = tempDir
 
-		if hdr.Typeflag != tar.TypeReg {
-			continue
-		}
-
-		var fileBuff bytes.Buffer
-		if _, err := io.Copy(&fileBuff, tr); err != nil {
-			return fmt.Errorf("failed to read file content: %w", err)
-		}
-
-		fileName := path.Base(hdr.Name)
-		if fileName != "" {
-			// import each key file into the in-memory keyring
-			if err := d.importKeyFromFile(kr, fileName, fileBuff.Bytes()); err != nil {
-				return fmt.Errorf("failed to import key file %s: %w", fileName, err)
-			}
-		}
+	kr, err := NewLocalKeyringFromDockerContainer(
+		context.TODO(), d.dockerClient, tempDir, d.containerKeyringDir, d.containerID)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return fmt.Errorf("failed to create keyring from container: %w", err)
 	}
 
 	d.localKeyring = kr
 	return nil
 }
 
-// importKeyFromFile parses a keyring file and imports the key into the in-memory keyring
-func (d *dockerKeyring) importKeyFromFile(kr keyring.Keyring, fileName string, content []byte) error {
-	// For test keyring backend, keys are stored as individual files
-	// The filename is typically the key name, and content is the key data
-
-	// Try to import as armored private key (common format)
-	if err := kr.ImportPrivKey(fileName, string(content), ""); err != nil {
-		return fmt.Errorf("unsupported key format in file %s: %w", fileName, err)
-	}
-
-	return nil
-}
-
-// persistKeyToContainer exports a key from the in-memory keyring and writes it to the Docker container
-func (d *dockerKeyring) persistKeyToContainer(ctx context.Context, uid string) error {
-	// Export the private key as armor
-	armor, err := d.localKeyring.ExportPrivKeyArmor(uid, "")
-	if err != nil {
-		return fmt.Errorf("failed to export private key: %w", err)
-	}
-
-	// Create a tar archive with the key file
+// createTarFromDirectory creates a tar archive from a directory
+func createTarFromDirectory(srcDir string) (*bytes.Reader, error) {
 	var tarBuf bytes.Buffer
 	tarWriter := tar.NewWriter(&tarBuf)
+	defer tarWriter.Close()
 
-	// Add the key file to the tar archive
-	keyFileName := uid // Use the UID as the filename
-	header := &tar.Header{
-		Name:     keyFileName,
-		Mode:     0600,
-		Size:     int64(len(armor)),
-		ModTime:  time.Now(),
-		Typeflag: tar.TypeReg,
+	err := filepath.Walk(srcDir, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcDir, filePath)
+		if err != nil {
+			return err
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+
+		header := &tar.Header{
+			Name:     relPath,
+			Mode:     int64(info.Mode()),
+			Size:     int64(len(content)),
+			ModTime:  info.ModTime(),
+			Typeflag: tar.TypeReg,
+		}
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := tarWriter.Write(content); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
-	if err := tarWriter.WriteHeader(header); err != nil {
-		return fmt.Errorf("failed to write tar header: %w", err)
+	return bytes.NewReader(tarBuf.Bytes()), nil
+}
+
+// persistKeyringToContainer copies the entire temp keyring directory to the Docker container
+func (d *dockerKeyring) persistKeyringToContainer() error {
+	if d.tempDir == "" {
+		return fmt.Errorf("temp directory not initialized")
 	}
 
-	if _, err := tarWriter.Write([]byte(armor)); err != nil {
-		return fmt.Errorf("failed to write key data to tar: %w", err)
+	keyringTestDir := filepath.Join(d.tempDir, "keyring-test")
+	tarReader, err := createTarFromDirectory(keyringTestDir)
+	if err != nil {
+		return fmt.Errorf("failed to create tar from temp directory: %w", err)
 	}
 
-	if err := tarWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close tar writer: %w", err)
-	}
-
-	// Copy the tar archive to the container's keyring directory
-	if err := d.dockerClient.CopyToContainer(ctx, d.containerID, d.containerKeyringDir, &tarBuf, container.CopyToContainerOptions{}); err != nil {
-		return fmt.Errorf("failed to copy key to container: %w", err)
+	// copy the entire tmp keyring directory to the container.
+	if err := d.dockerClient.CopyToContainer(context.TODO(), d.containerID, d.containerKeyringDir, tarReader, container.CopyToContainerOptions{}); err != nil {
+		return fmt.Errorf("failed to copy keyring directory to container: %w", err)
 	}
 
 	return nil
 }
 
-// deleteKeyFromContainer removes a key file from the Docker container
+// deleteKeyFromContainer removes all key-related files from the Docker container
 func (d *dockerKeyring) deleteKeyFromContainer(ctx context.Context, uid string) error {
-	// Execute rm command in the container to delete the key file
-	keyFilePath := filepath.Join(d.containerKeyringDir, uid)
+	// Delete main key file, .info file, and any .address files related to this key
+	// Use a glob pattern to match all files that might be related to this key
+	keyPattern := filepath.Join(d.containerKeyringDir, uid+"*")
 
 	execConfig := container.ExecOptions{
-		Cmd: []string{"rm", "-f", keyFilePath},
+		Cmd: []string{"sh", "-c", fmt.Sprintf("rm -f %s", keyPattern)},
 	}
 
 	exec, err := d.dockerClient.ContainerExecCreate(ctx, d.containerID, execConfig)
@@ -165,6 +157,25 @@ func (d *dockerKeyring) deleteKeyFromContainer(ctx context.Context, uid string) 
 
 	if err := d.dockerClient.ContainerExecStart(ctx, exec.ID, container.ExecStartOptions{}); err != nil {
 		return fmt.Errorf("failed to execute key deletion: %w", err)
+	}
+
+	// Also need to find and delete the .address file which is named by the address, not the uid
+	// First get the key record to find its address, then delete the corresponding .address file
+	record, err := d.localKeyring.Key(uid)
+	if err == nil && record != nil {
+		// Get the address and delete the corresponding .address file
+		addr, err := record.GetAddress()
+		if err == nil {
+			addrFilePath := filepath.Join(d.containerKeyringDir, addr.String()+".address")
+			execConfig := container.ExecOptions{
+				Cmd: []string{"rm", "-f", addrFilePath},
+			}
+
+			exec, err := d.dockerClient.ContainerExecCreate(ctx, d.containerID, execConfig)
+			if err == nil {
+				_ = d.dockerClient.ContainerExecStart(ctx, exec.ID, container.ExecStartOptions{})
+			}
+		}
 	}
 
 	return nil
@@ -193,21 +204,21 @@ func (d *dockerKeyring) renameKeyInContainer(ctx context.Context, from, to strin
 }
 
 func (d *dockerKeyring) Backend() string {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return ""
 	}
 	return d.localKeyring.Backend()
 }
 
 func (d *dockerKeyring) List() ([]*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 	return d.localKeyring.List()
 }
 
 func (d *dockerKeyring) SupportedAlgorithms() (keyring.SigningAlgoList, keyring.SigningAlgoList) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		// Return default algorithms if initialization fails
 		return keyring.SigningAlgoList{}, keyring.SigningAlgoList{}
 	}
@@ -215,30 +226,28 @@ func (d *dockerKeyring) SupportedAlgorithms() (keyring.SigningAlgoList, keyring.
 }
 
 func (d *dockerKeyring) Key(uid string) (*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 	return d.localKeyring.Key(uid)
 }
 
 func (d *dockerKeyring) KeyByAddress(address sdk.Address) (*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 	return d.localKeyring.KeyByAddress(address)
 }
 
 func (d *dockerKeyring) Delete(uid string) error {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return err
 	}
 
-	// Delete from in-memory keyring
 	if err := d.localKeyring.Delete(uid); err != nil {
 		return fmt.Errorf("failed to delete key from local keyring: %w", err)
 	}
 
-	// Delete from Docker container
 	if err := d.deleteKeyFromContainer(context.Background(), uid); err != nil {
 		return fmt.Errorf("failed to delete key from container: %w", err)
 	}
@@ -247,22 +256,19 @@ func (d *dockerKeyring) Delete(uid string) error {
 }
 
 func (d *dockerKeyring) DeleteByAddress(address sdk.Address) error {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return err
 	}
 
-	// First get the key record to find the UID
 	record, err := d.localKeyring.KeyByAddress(address)
 	if err != nil {
 		return fmt.Errorf("failed to find key by address: %w", err)
 	}
 
-	// Delete from in-memory keyring
 	if err := d.localKeyring.DeleteByAddress(address); err != nil {
 		return fmt.Errorf("failed to delete key from local keyring: %w", err)
 	}
 
-	// Delete from Docker container using the UID
 	if err := d.deleteKeyFromContainer(context.Background(), record.Name); err != nil {
 		return fmt.Errorf("failed to delete key from container: %w", err)
 	}
@@ -271,16 +277,14 @@ func (d *dockerKeyring) DeleteByAddress(address sdk.Address) error {
 }
 
 func (d *dockerKeyring) Rename(from, to string) error {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return err
 	}
 
-	// Rename in in-memory keyring
 	if err := d.localKeyring.Rename(from, to); err != nil {
 		return fmt.Errorf("failed to rename key in local keyring: %w", err)
 	}
 
-	// Rename in Docker container
 	if err := d.renameKeyInContainer(context.Background(), from, to); err != nil {
 		return fmt.Errorf("failed to rename key in container: %w", err)
 	}
@@ -289,18 +293,18 @@ func (d *dockerKeyring) Rename(from, to string) error {
 }
 
 func (d *dockerKeyring) NewMnemonic(uid string, language keyring.Language, hdPath, bip39Passphrase string, algo keyring.SignatureAlgo) (*keyring.Record, string, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, "", err
 	}
 
-	// Create new mnemonic in the in-memory keyring
+	// create new mnemonic in the local keyring
 	record, mnemonic, err := d.localKeyring.NewMnemonic(uid, language, hdPath, bip39Passphrase, algo)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create new mnemonic: %w", err)
 	}
 
-	// Persist the new key to the Docker container
-	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+	// persist the new key to the Docker container
+	if err := d.persistKeyringToContainer(); err != nil {
 		return nil, "", fmt.Errorf("failed to persist key to container: %w", err)
 	}
 
@@ -308,7 +312,7 @@ func (d *dockerKeyring) NewMnemonic(uid string, language keyring.Language, hdPat
 }
 
 func (d *dockerKeyring) NewAccount(uid, mnemonic, bip39Passphrase, hdPath string, algo keyring.SignatureAlgo) (*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 
@@ -319,7 +323,7 @@ func (d *dockerKeyring) NewAccount(uid, mnemonic, bip39Passphrase, hdPath string
 	}
 
 	// Persist the new key to the Docker container
-	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+	if err := d.persistKeyringToContainer(); err != nil {
 		return nil, fmt.Errorf("failed to persist key to container: %w", err)
 	}
 
@@ -331,7 +335,7 @@ func (d *dockerKeyring) SaveLedgerKey(uid string, algo keyring.SignatureAlgo, hr
 }
 
 func (d *dockerKeyring) SaveOfflineKey(uid string, pubkey types.PubKey) (*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 
@@ -342,7 +346,7 @@ func (d *dockerKeyring) SaveOfflineKey(uid string, pubkey types.PubKey) (*keyrin
 	}
 
 	// Persist the key to the Docker container
-	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+	if err := d.persistKeyringToContainer(); err != nil {
 		return nil, fmt.Errorf("failed to persist key to container: %w", err)
 	}
 
@@ -350,7 +354,7 @@ func (d *dockerKeyring) SaveOfflineKey(uid string, pubkey types.PubKey) (*keyrin
 }
 
 func (d *dockerKeyring) SaveMultisig(uid string, pubkey types.PubKey) (*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 
@@ -361,7 +365,7 @@ func (d *dockerKeyring) SaveMultisig(uid string, pubkey types.PubKey) (*keyring.
 	}
 
 	// Persist the key to the Docker container
-	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+	if err := d.persistKeyringToContainer(); err != nil {
 		return nil, fmt.Errorf("failed to persist key to container: %w", err)
 	}
 
@@ -369,21 +373,21 @@ func (d *dockerKeyring) SaveMultisig(uid string, pubkey types.PubKey) (*keyring.
 }
 
 func (d *dockerKeyring) Sign(uid string, msg []byte, signMode signing.SignMode) ([]byte, types.PubKey, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, nil, err
 	}
 	return d.localKeyring.Sign(uid, msg, signMode)
 }
 
 func (d *dockerKeyring) SignByAddress(address sdk.Address, msg []byte, signMode signing.SignMode) ([]byte, types.PubKey, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, nil, err
 	}
 	return d.localKeyring.SignByAddress(address, msg, signMode)
 }
 
 func (d *dockerKeyring) ImportPrivKey(uid, armor, passphrase string) error {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return err
 	}
 
@@ -393,7 +397,7 @@ func (d *dockerKeyring) ImportPrivKey(uid, armor, passphrase string) error {
 	}
 
 	// Persist the key to the Docker container
-	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+	if err := d.persistKeyringToContainer(); err != nil {
 		return fmt.Errorf("failed to persist key to container: %w", err)
 	}
 
@@ -401,7 +405,7 @@ func (d *dockerKeyring) ImportPrivKey(uid, armor, passphrase string) error {
 }
 
 func (d *dockerKeyring) ImportPrivKeyHex(uid, privKey, algoStr string) error {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return err
 	}
 
@@ -410,8 +414,8 @@ func (d *dockerKeyring) ImportPrivKeyHex(uid, privKey, algoStr string) error {
 		return fmt.Errorf("failed to import private key hex: %w", err)
 	}
 
-	// Persist the key to the Docker container
-	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+	// persist the key to the Docker container
+	if err := d.persistKeyringToContainer(); err != nil {
 		return fmt.Errorf("failed to persist key to container: %w", err)
 	}
 
@@ -419,42 +423,42 @@ func (d *dockerKeyring) ImportPrivKeyHex(uid, privKey, algoStr string) error {
 }
 
 func (d *dockerKeyring) ImportPubKey(uid, armor string) error {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return err
 	}
 	return d.localKeyring.ImportPubKey(uid, armor)
 }
 
 func (d *dockerKeyring) ExportPubKeyArmor(uid string) (string, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return "", err
 	}
 	return d.localKeyring.ExportPubKeyArmor(uid)
 }
 
 func (d *dockerKeyring) ExportPubKeyArmorByAddress(address sdk.Address) (string, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return "", err
 	}
 	return d.localKeyring.ExportPubKeyArmorByAddress(address)
 }
 
 func (d *dockerKeyring) ExportPrivKeyArmor(uid, encryptPassphrase string) (armor string, err error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return "", err
 	}
 	return d.localKeyring.ExportPrivKeyArmor(uid, encryptPassphrase)
 }
 
 func (d *dockerKeyring) ExportPrivKeyArmorByAddress(address sdk.Address, encryptPassphrase string) (armor string, err error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return "", err
 	}
 	return d.localKeyring.ExportPrivKeyArmorByAddress(address, encryptPassphrase)
 }
 
 func (d *dockerKeyring) MigrateAll() ([]*keyring.Record, error) {
-	if err := d.ensureInitialized(context.Background()); err != nil {
+	if err := d.ensureInitialized(); err != nil {
 		return nil, err
 	}
 	return d.localKeyring.MigrateAll()

--- a/framework/docker/internal/docker_keyring.go
+++ b/framework/docker/internal/docker_keyring.go
@@ -1,0 +1,461 @@
+package docker
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/docker/docker/api/types/container"
+	"github.com/moby/moby/client"
+	"io"
+	"path"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+var _ keyring.Keyring = &dockerKeyring{}
+
+type dockerKeyring struct {
+	mu                  sync.RWMutex
+	dockerClient        *client.Client
+	containerID         string
+	containerKeyringDir string
+	cdc                 codec.Codec
+
+	// Lazy-loaded keyring from container
+	localKeyring keyring.Keyring
+	tempDir      string
+}
+
+// NewDockerKeyring creates a new keyring that proxies to Docker container keys
+func NewDockerKeyring(dockerClient *client.Client, containerID, containerKeyringDir string, cdc codec.Codec) keyring.Keyring {
+	return &dockerKeyring{
+		dockerClient:        dockerClient,
+		containerID:         containerID,
+		containerKeyringDir: containerKeyringDir,
+		cdc:                 cdc,
+	}
+}
+
+// ensureInitialized lazily loads the keyring from the Docker container into memory
+func (d *dockerKeyring) ensureInitialized(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.localKeyring != nil {
+		return nil
+	}
+
+	kr := keyring.NewInMemory(d.cdc)
+
+	// copy the contents of the keyring directory from the docker container.
+	reader, _, err := d.dockerClient.CopyFromContainer(ctx, d.containerID, d.containerKeyringDir)
+	if err != nil {
+		return fmt.Errorf("failed to copy keyring from container: %w", err)
+	}
+	defer reader.Close()
+
+	// Extract and parse keyring files
+	tr := tar.NewReader(reader)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar entry: %w", err)
+		}
+
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		var fileBuff bytes.Buffer
+		if _, err := io.Copy(&fileBuff, tr); err != nil {
+			return fmt.Errorf("failed to read file content: %w", err)
+		}
+
+		fileName := path.Base(hdr.Name)
+		if fileName != "" {
+			// import each key file into the in-memory keyring
+			if err := d.importKeyFromFile(kr, fileName, fileBuff.Bytes()); err != nil {
+				return fmt.Errorf("failed to import key file %s: %w", fileName, err)
+			}
+		}
+	}
+
+	d.localKeyring = kr
+	return nil
+}
+
+// importKeyFromFile parses a keyring file and imports the key into the in-memory keyring
+func (d *dockerKeyring) importKeyFromFile(kr keyring.Keyring, fileName string, content []byte) error {
+	// For test keyring backend, keys are stored as individual files
+	// The filename is typically the key name, and content is the key data
+
+	// Try to import as armored private key (common format)
+	if err := kr.ImportPrivKey(fileName, string(content), ""); err != nil {
+		return fmt.Errorf("unsupported key format in file %s: %w", fileName, err)
+	}
+
+	return nil
+}
+
+// persistKeyToContainer exports a key from the in-memory keyring and writes it to the Docker container
+func (d *dockerKeyring) persistKeyToContainer(ctx context.Context, uid string) error {
+	// Export the private key as armor
+	armor, err := d.localKeyring.ExportPrivKeyArmor(uid, "")
+	if err != nil {
+		return fmt.Errorf("failed to export private key: %w", err)
+	}
+
+	// Create a tar archive with the key file
+	var tarBuf bytes.Buffer
+	tarWriter := tar.NewWriter(&tarBuf)
+
+	// Add the key file to the tar archive
+	keyFileName := uid // Use the UID as the filename
+	header := &tar.Header{
+		Name:     keyFileName,
+		Mode:     0600,
+		Size:     int64(len(armor)),
+		ModTime:  time.Now(),
+		Typeflag: tar.TypeReg,
+	}
+
+	if err := tarWriter.WriteHeader(header); err != nil {
+		return fmt.Errorf("failed to write tar header: %w", err)
+	}
+
+	if _, err := tarWriter.Write([]byte(armor)); err != nil {
+		return fmt.Errorf("failed to write key data to tar: %w", err)
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close tar writer: %w", err)
+	}
+
+	// Copy the tar archive to the container's keyring directory
+	if err := d.dockerClient.CopyToContainer(ctx, d.containerID, d.containerKeyringDir, &tarBuf, container.CopyToContainerOptions{}); err != nil {
+		return fmt.Errorf("failed to copy key to container: %w", err)
+	}
+
+	return nil
+}
+
+// deleteKeyFromContainer removes a key file from the Docker container
+func (d *dockerKeyring) deleteKeyFromContainer(ctx context.Context, uid string) error {
+	// Execute rm command in the container to delete the key file
+	keyFilePath := filepath.Join(d.containerKeyringDir, uid)
+
+	execConfig := container.ExecOptions{
+		Cmd: []string{"rm", "-f", keyFilePath},
+	}
+
+	exec, err := d.dockerClient.ContainerExecCreate(ctx, d.containerID, execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec for key deletion: %w", err)
+	}
+
+	if err := d.dockerClient.ContainerExecStart(ctx, exec.ID, container.ExecStartOptions{}); err != nil {
+		return fmt.Errorf("failed to execute key deletion: %w", err)
+	}
+
+	return nil
+}
+
+// renameKeyInContainer renames a key file in the Docker container
+func (d *dockerKeyring) renameKeyInContainer(ctx context.Context, from, to string) error {
+	// Execute mv command in the container to rename the key file
+	fromPath := filepath.Join(d.containerKeyringDir, from)
+	toPath := filepath.Join(d.containerKeyringDir, to)
+
+	execConfig := container.ExecOptions{
+		Cmd: []string{"mv", fromPath, toPath},
+	}
+
+	exec, err := d.dockerClient.ContainerExecCreate(ctx, d.containerID, execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec for key rename: %w", err)
+	}
+
+	if err := d.dockerClient.ContainerExecStart(ctx, exec.ID, container.ExecStartOptions{}); err != nil {
+		return fmt.Errorf("failed to execute key rename: %w", err)
+	}
+
+	return nil
+}
+
+func (d *dockerKeyring) Backend() string {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return ""
+	}
+	return d.localKeyring.Backend()
+}
+
+func (d *dockerKeyring) List() ([]*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+	return d.localKeyring.List()
+}
+
+func (d *dockerKeyring) SupportedAlgorithms() (keyring.SigningAlgoList, keyring.SigningAlgoList) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		// Return default algorithms if initialization fails
+		return keyring.SigningAlgoList{}, keyring.SigningAlgoList{}
+	}
+	return d.localKeyring.SupportedAlgorithms()
+}
+
+func (d *dockerKeyring) Key(uid string) (*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+	return d.localKeyring.Key(uid)
+}
+
+func (d *dockerKeyring) KeyByAddress(address sdk.Address) (*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+	return d.localKeyring.KeyByAddress(address)
+}
+
+func (d *dockerKeyring) Delete(uid string) error {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return err
+	}
+
+	// Delete from in-memory keyring
+	if err := d.localKeyring.Delete(uid); err != nil {
+		return fmt.Errorf("failed to delete key from local keyring: %w", err)
+	}
+
+	// Delete from Docker container
+	if err := d.deleteKeyFromContainer(context.Background(), uid); err != nil {
+		return fmt.Errorf("failed to delete key from container: %w", err)
+	}
+
+	return nil
+}
+
+func (d *dockerKeyring) DeleteByAddress(address sdk.Address) error {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return err
+	}
+
+	// First get the key record to find the UID
+	record, err := d.localKeyring.KeyByAddress(address)
+	if err != nil {
+		return fmt.Errorf("failed to find key by address: %w", err)
+	}
+
+	// Delete from in-memory keyring
+	if err := d.localKeyring.DeleteByAddress(address); err != nil {
+		return fmt.Errorf("failed to delete key from local keyring: %w", err)
+	}
+
+	// Delete from Docker container using the UID
+	if err := d.deleteKeyFromContainer(context.Background(), record.Name); err != nil {
+		return fmt.Errorf("failed to delete key from container: %w", err)
+	}
+
+	return nil
+}
+
+func (d *dockerKeyring) Rename(from, to string) error {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return err
+	}
+
+	// Rename in in-memory keyring
+	if err := d.localKeyring.Rename(from, to); err != nil {
+		return fmt.Errorf("failed to rename key in local keyring: %w", err)
+	}
+
+	// Rename in Docker container
+	if err := d.renameKeyInContainer(context.Background(), from, to); err != nil {
+		return fmt.Errorf("failed to rename key in container: %w", err)
+	}
+
+	return nil
+}
+
+func (d *dockerKeyring) NewMnemonic(uid string, language keyring.Language, hdPath, bip39Passphrase string, algo keyring.SignatureAlgo) (*keyring.Record, string, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, "", err
+	}
+
+	// Create new mnemonic in the in-memory keyring
+	record, mnemonic, err := d.localKeyring.NewMnemonic(uid, language, hdPath, bip39Passphrase, algo)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create new mnemonic: %w", err)
+	}
+
+	// Persist the new key to the Docker container
+	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+		return nil, "", fmt.Errorf("failed to persist key to container: %w", err)
+	}
+
+	return record, mnemonic, nil
+}
+
+func (d *dockerKeyring) NewAccount(uid, mnemonic, bip39Passphrase, hdPath string, algo keyring.SignatureAlgo) (*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+
+	// Create new account in the in-memory keyring
+	record, err := d.localKeyring.NewAccount(uid, mnemonic, bip39Passphrase, hdPath, algo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new account: %w", err)
+	}
+
+	// Persist the new key to the Docker container
+	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+		return nil, fmt.Errorf("failed to persist key to container: %w", err)
+	}
+
+	return record, nil
+}
+
+func (d *dockerKeyring) SaveLedgerKey(uid string, algo keyring.SignatureAlgo, hrp string, coinType, account, index uint32) (*keyring.Record, error) {
+	return nil, fmt.Errorf("ledger key saving not supported on docker keyring")
+}
+
+func (d *dockerKeyring) SaveOfflineKey(uid string, pubkey types.PubKey) (*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+
+	// Save offline key in the in-memory keyring
+	record, err := d.localKeyring.SaveOfflineKey(uid, pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save offline key: %w", err)
+	}
+
+	// Persist the key to the Docker container
+	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+		return nil, fmt.Errorf("failed to persist key to container: %w", err)
+	}
+
+	return record, nil
+}
+
+func (d *dockerKeyring) SaveMultisig(uid string, pubkey types.PubKey) (*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+
+	// Save multisig key in the in-memory keyring
+	record, err := d.localKeyring.SaveMultisig(uid, pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save multisig key: %w", err)
+	}
+
+	// Persist the key to the Docker container
+	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+		return nil, fmt.Errorf("failed to persist key to container: %w", err)
+	}
+
+	return record, nil
+}
+
+func (d *dockerKeyring) Sign(uid string, msg []byte, signMode signing.SignMode) ([]byte, types.PubKey, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, nil, err
+	}
+	return d.localKeyring.Sign(uid, msg, signMode)
+}
+
+func (d *dockerKeyring) SignByAddress(address sdk.Address, msg []byte, signMode signing.SignMode) ([]byte, types.PubKey, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, nil, err
+	}
+	return d.localKeyring.SignByAddress(address, msg, signMode)
+}
+
+func (d *dockerKeyring) ImportPrivKey(uid, armor, passphrase string) error {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return err
+	}
+
+	// Import private key into the in-memory keyring
+	if err := d.localKeyring.ImportPrivKey(uid, armor, passphrase); err != nil {
+		return fmt.Errorf("failed to import private key: %w", err)
+	}
+
+	// Persist the key to the Docker container
+	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+		return fmt.Errorf("failed to persist key to container: %w", err)
+	}
+
+	return nil
+}
+
+func (d *dockerKeyring) ImportPrivKeyHex(uid, privKey, algoStr string) error {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return err
+	}
+
+	// Import private key hex into the in-memory keyring
+	if err := d.localKeyring.ImportPrivKeyHex(uid, privKey, algoStr); err != nil {
+		return fmt.Errorf("failed to import private key hex: %w", err)
+	}
+
+	// Persist the key to the Docker container
+	if err := d.persistKeyToContainer(context.Background(), uid); err != nil {
+		return fmt.Errorf("failed to persist key to container: %w", err)
+	}
+
+	return nil
+}
+
+func (d *dockerKeyring) ImportPubKey(uid, armor string) error {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return err
+	}
+	return d.localKeyring.ImportPubKey(uid, armor)
+}
+
+func (d *dockerKeyring) ExportPubKeyArmor(uid string) (string, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return "", err
+	}
+	return d.localKeyring.ExportPubKeyArmor(uid)
+}
+
+func (d *dockerKeyring) ExportPubKeyArmorByAddress(address sdk.Address) (string, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return "", err
+	}
+	return d.localKeyring.ExportPubKeyArmorByAddress(address)
+}
+
+func (d *dockerKeyring) ExportPrivKeyArmor(uid, encryptPassphrase string) (armor string, err error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return "", err
+	}
+	return d.localKeyring.ExportPrivKeyArmor(uid, encryptPassphrase)
+}
+
+func (d *dockerKeyring) ExportPrivKeyArmorByAddress(address sdk.Address, encryptPassphrase string) (armor string, err error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return "", err
+	}
+	return d.localKeyring.ExportPrivKeyArmorByAddress(address, encryptPassphrase)
+}
+
+func (d *dockerKeyring) MigrateAll() ([]*keyring.Record, error) {
+	if err := d.ensureInitialized(context.Background()); err != nil {
+		return nil, err
+	}
+	return d.localKeyring.MigrateAll()
+}

--- a/framework/docker/internal/docker_keyring_test.go
+++ b/framework/docker/internal/docker_keyring_test.go
@@ -32,17 +32,16 @@ func TestDockerKeyringTestSuite(t *testing.T) {
 }
 
 func (s *DockerKeyringTestSuite) SetupSuite() {
-	// Initialize Docker client
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	s.Require().NoError(err)
+
 	s.dockerClient = dockerClient
 
-	// Create codec
 	registry := codectypes.NewInterfaceRegistry()
 	cryptocodec.RegisterInterfaces(registry)
 	s.cdc = codec.NewProtoCodec(registry)
 
-	// Pull a minimal image for testing
+	// pull a minimal image for testing
 	ctx := context.Background()
 	pullReader, err := s.dockerClient.ImagePull(ctx, "alpine:latest", image.PullOptions{})
 	s.Require().NoError(err)
@@ -54,29 +53,29 @@ func (s *DockerKeyringTestSuite) SetupSuite() {
 	// create a test container
 	containerConfig := &container.Config{
 		Image: "alpine:latest",
-		Cmd:   []string{"sleep", "3600"}, // Keep container running
+		Cmd:   []string{"sleep", "3600"}, // keep container running
 	}
 
 	resp, err := s.dockerClient.ContainerCreate(ctx, containerConfig, nil, nil, nil, "")
 	s.Require().NoError(err)
 	s.containerID = resp.ID
 
-	// Start the container
 	err = s.dockerClient.ContainerStart(ctx, s.containerID, container.StartOptions{})
 	s.Require().NoError(err)
 
-	// Wait for container to be ready
+	// wait for container to be ready
 	time.Sleep(time.Second)
 
-	// Set up keyring directory in container
+	// wet up keyring directory in container
 	s.keyringDir = "/tmp/keyring-test"
 
-	// Create keyring directory in container
+	// create keyring directory in container
 	execConfig := container.ExecOptions{
 		Cmd: []string{"mkdir", "-p", s.keyringDir},
 	}
 	exec, err := s.dockerClient.ContainerExecCreate(ctx, s.containerID, execConfig)
 	s.Require().NoError(err)
+
 	err = s.dockerClient.ContainerExecStart(ctx, exec.ID, container.ExecStartOptions{})
 	s.Require().NoError(err)
 

--- a/framework/docker/internal/docker_keyring_test.go
+++ b/framework/docker/internal/docker_keyring_test.go
@@ -87,9 +87,8 @@ func (s *DockerKeyringTestSuite) SetupSuite() {
 func (s *DockerKeyringTestSuite) TearDownSuite() {
 	if s.containerID != "" {
 		ctx := context.Background()
-		// Stop and remove the test container
-		s.dockerClient.ContainerStop(ctx, s.containerID, container.StopOptions{})
-		s.dockerClient.ContainerRemove(ctx, s.containerID, container.RemoveOptions{})
+		_ = s.dockerClient.ContainerStop(ctx, s.containerID, container.StopOptions{})
+		_ = s.dockerClient.ContainerRemove(ctx, s.containerID, container.RemoveOptions{})
 	}
 }
 

--- a/framework/docker/internal/docker_keyring_test.go
+++ b/framework/docker/internal/docker_keyring_test.go
@@ -1,0 +1,323 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/suite"
+)
+
+type DockerKeyringTestSuite struct {
+	suite.Suite
+	dockerClient *client.Client
+	containerID  string
+	keyringDir   string
+	cdc          codec.Codec
+	kr           keyring.Keyring
+}
+
+func TestDockerKeyringTestSuite(t *testing.T) {
+	suite.Run(t, new(DockerKeyringTestSuite))
+}
+
+func (s *DockerKeyringTestSuite) SetupSuite() {
+	// Initialize Docker client
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	s.Require().NoError(err)
+	s.dockerClient = dockerClient
+
+	// Create codec
+	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	s.cdc = codec.NewProtoCodec(registry)
+
+	// Pull a minimal image for testing
+	ctx := context.Background()
+	pullReader, err := s.dockerClient.ImagePull(ctx, "alpine:latest", image.PullOptions{})
+	s.Require().NoError(err)
+
+	_, err = io.Copy(io.Discard, pullReader)
+	_ = pullReader.Close()
+	s.Require().NoError(err)
+
+	// create a test container
+	containerConfig := &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"sleep", "3600"}, // Keep container running
+	}
+
+	resp, err := s.dockerClient.ContainerCreate(ctx, containerConfig, nil, nil, nil, "")
+	s.Require().NoError(err)
+	s.containerID = resp.ID
+
+	// Start the container
+	err = s.dockerClient.ContainerStart(ctx, s.containerID, container.StartOptions{})
+	s.Require().NoError(err)
+
+	// Wait for container to be ready
+	time.Sleep(time.Second)
+
+	// Set up keyring directory in container
+	s.keyringDir = "/tmp/keyring-test"
+
+	// Create keyring directory in container
+	execConfig := container.ExecOptions{
+		Cmd: []string{"mkdir", "-p", s.keyringDir},
+	}
+	exec, err := s.dockerClient.ContainerExecCreate(ctx, s.containerID, execConfig)
+	s.Require().NoError(err)
+	err = s.dockerClient.ContainerExecStart(ctx, exec.ID, container.ExecStartOptions{})
+	s.Require().NoError(err)
+
+	// create the docker keyring
+	s.kr = NewDockerKeyring(s.dockerClient, s.containerID, s.keyringDir, s.cdc)
+}
+
+func (s *DockerKeyringTestSuite) TearDownSuite() {
+	if s.containerID != "" {
+		ctx := context.Background()
+		// Stop and remove the test container
+		s.dockerClient.ContainerStop(ctx, s.containerID, container.StopOptions{})
+		s.dockerClient.ContainerRemove(ctx, s.containerID, container.RemoveOptions{})
+	}
+}
+
+func (s *DockerKeyringTestSuite) TestBackend() {
+	backend := s.kr.Backend()
+	s.Require().NotEmpty(backend)
+}
+
+func (s *DockerKeyringTestSuite) TestNewMnemonic() {
+	// Create a new mnemonic
+	record, mnemonic, err := s.kr.NewMnemonic(
+		"test-key",
+		keyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		hd.Secp256k1,
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(record)
+	s.Require().NotEmpty(mnemonic)
+	s.Require().Equal("test-key", record.Name)
+
+	// verify the key exists in the keyring
+	retrievedRecord, err := s.kr.Key("test-key")
+	s.Require().NoError(err)
+	s.Require().Equal(record.Name, retrievedRecord.Name)
+
+	// verify the key was persisted to container by creating a new keyring instance
+	newKr := NewDockerKeyring(s.dockerClient, s.containerID, s.keyringDir, s.cdc)
+	persistedRecord, err := newKr.Key("test-key")
+	s.Require().NoError(err)
+	s.Require().Equal(record.Name, persistedRecord.Name)
+}
+
+func (s *DockerKeyringTestSuite) TestNewAccount() {
+	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	record, err := s.kr.NewAccount(
+		"test-account",
+		mnemonic,
+		"",
+		"m/44'/118'/0'/0/0",
+		hd.Secp256k1,
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(record)
+	s.Require().Equal("test-account", record.Name)
+
+	// verify the key exists
+	retrievedRecord, err := s.kr.Key("test-account")
+	s.Require().NoError(err)
+	s.Require().Equal(record.Name, retrievedRecord.Name)
+}
+
+func (s *DockerKeyringTestSuite) TestList() {
+	// create a few test keys
+	_, _, err := s.kr.NewMnemonic("key1", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err)
+
+	_, _, err = s.kr.NewMnemonic("key2", keyring.English, "m/44'/118'/0'/0/1", "", hd.Secp256k1)
+	s.Require().NoError(err)
+
+	// list all keys
+	records, err := s.kr.List()
+	s.Require().NoError(err)
+	s.Require().GreaterOrEqual(len(records), 2)
+
+	// Check that our keys are in the list
+	keyNames := make(map[string]bool)
+	for _, record := range records {
+		keyNames[record.Name] = true
+	}
+	s.Require().True(keyNames["key1"])
+	s.Require().True(keyNames["key2"])
+}
+
+func (s *DockerKeyringTestSuite) TestSign() {
+	// Create a test key
+	record, _, err := s.kr.NewMnemonic("sign-test", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err)
+	// Test message to sign
+	message := []byte("test message to sign")
+
+	// sign the message
+	signature, pubKey, err := s.kr.Sign("sign-test", message, signing.SignMode_SIGN_MODE_DIRECT)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(signature)
+	s.Require().NotNil(pubKey)
+
+	// verify signature matches the record's public key
+	recordPubKey, err := record.GetPubKey()
+	s.Require().NoError(err)
+	s.Require().True(pubKey.Equals(recordPubKey))
+}
+
+func (s *DockerKeyringTestSuite) TestDelete() {
+	_, _, err := s.kr.NewMnemonic("delete-test", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err)
+
+	// verify the key exists
+	_, err = s.kr.Key("delete-test")
+	s.Require().NoError(err)
+
+	// delete the key
+	err = s.kr.Delete("delete-test")
+	s.Require().NoError(err)
+
+	// verify the key no longer exists
+	_, err = s.kr.Key("delete-test")
+	s.Require().Error(err)
+
+	// verify the key was deleted from container by creating a new keyring instance
+	newKr := NewDockerKeyring(s.dockerClient, s.containerID, s.keyringDir, s.cdc)
+	_, err = newKr.Key("delete-test")
+	s.Require().Error(err)
+}
+
+func (s *DockerKeyringTestSuite) TestDeleteByAddress() {
+	record, _, err := s.kr.NewMnemonic("delete-by-addr-test", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err, "failed to create key")
+
+	addr, err := record.GetAddress()
+	s.Require().NoError(err, "failed to get address")
+
+	_, err = s.kr.KeyByAddress(addr)
+	s.Require().NoError(err, "failed to get key by address")
+
+	err = s.kr.DeleteByAddress(addr)
+	s.Require().NoError(err, "failed to delete key by address")
+
+	_, err = s.kr.KeyByAddress(addr)
+	s.Require().Error(err, "expected error when getting key by address after deletion")
+}
+
+func (s *DockerKeyringTestSuite) TestRename() {
+	originalRecord, _, err := s.kr.NewMnemonic("original-name", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err, "failed to create key")
+
+	_, err = s.kr.Key("original-name")
+	s.Require().NoError(err, "failed to get key")
+
+	err = s.kr.Rename("original-name", "new-name")
+	s.Require().NoError(err, "failed to rename key")
+
+	renamedRecord, err := s.kr.Key("new-name")
+	s.Require().NoError(err, "failed to get renamed key")
+	s.Require().Equal("new-name", renamedRecord.Name)
+
+	_, err = s.kr.Key("original-name")
+	s.Require().Error(err, "expected error when getting original key after renaming")
+
+	originalPubKey, err := originalRecord.GetPubKey()
+	s.Require().NoError(err, "failed to get original key's pubkey")
+	renamedPubKey, err := renamedRecord.GetPubKey()
+	s.Require().NoError(err, "failed to get renamed key's pubkey")
+	s.Require().True(originalPubKey.Equals(renamedPubKey))
+
+	// verify persistence by creating a new keyring instance
+	newKr := NewDockerKeyring(s.dockerClient, s.containerID, s.keyringDir, s.cdc)
+	persistedRecord, err := newKr.Key("new-name")
+	s.Require().NoError(err, "failed to get renamed key from new keyring")
+	s.Require().Equal("new-name", persistedRecord.Name)
+}
+
+func (s *DockerKeyringTestSuite) TestImportPrivKey() {
+	// first create a key to get its armor
+	record, _, err := s.kr.NewMnemonic("export-test", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err, "failed to create key")
+
+	armor, err := s.kr.ExportPrivKeyArmor("export-test", "test-password")
+	s.Require().NoError(err, "failed to export key")
+	s.Require().NotEmpty(armor, "exported key is empty")
+
+	err = s.kr.Delete("export-test")
+	s.Require().NoError(err, "failed to delete key")
+
+	// import the key with a new name
+	err = s.kr.ImportPrivKey("import-test", armor, "test-password")
+	s.Require().NoError(err, "failed to import key")
+
+	// verify the imported key works
+	importedRecord, err := s.kr.Key("import-test")
+	s.Require().NoError(err, "failed to get imported key")
+	s.Require().Equal("import-test", importedRecord.Name, "imported key has wrong name")
+
+	// verify the public keys match
+	originalPubKey, err := record.GetPubKey()
+	s.Require().NoError(err)
+	importedPubKey, err := importedRecord.GetPubKey()
+	s.Require().NoError(err)
+	s.Require().True(originalPubKey.Equals(importedPubKey))
+}
+
+func (s *DockerKeyringTestSuite) TestExportPubKeyArmor() {
+	_, _, err := s.kr.NewMnemonic("export-pub-test", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err)
+
+	armor, err := s.kr.ExportPubKeyArmor("export-pub-test")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(armor)
+	s.Require().Contains(armor, "-----BEGIN")
+	s.Require().Contains(armor, "-----END")
+}
+
+func (s *DockerKeyringTestSuite) TestSupportedAlgorithms() {
+	supported, _ := s.kr.SupportedAlgorithms()
+	s.Require().NotEmpty(supported)
+}
+
+func (s *DockerKeyringTestSuite) TestPersistenceAcrossInstances() {
+	// create a key with the first keyring instance
+	originalRecord, _, err := s.kr.NewMnemonic("persistence-test", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	s.Require().NoError(err)
+
+	// create a new keyring instance pointing to the same container
+	newKr := NewDockerKeyring(s.dockerClient, s.containerID, s.keyringDir, s.cdc)
+
+	// verify the key exists in the new instance
+	persistedRecord, err := newKr.Key("persistence-test")
+	s.Require().NoError(err)
+	s.Require().Equal(originalRecord.Name, persistedRecord.Name)
+
+	// verify the public keys match
+	originalPubKey, err := originalRecord.GetPubKey()
+	s.Require().NoError(err)
+	persistedPubKey, err := persistedRecord.GetPubKey()
+	s.Require().NoError(err)
+	s.Require().True(originalPubKey.Equals(persistedPubKey))
+}

--- a/framework/docker/internal/keyring.go
+++ b/framework/docker/internal/keyring.go
@@ -25,7 +25,7 @@ func NewLocalKeyringFromDockerContainer(ctx context.Context, dc *client.Client, 
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(localDirectory, "keyring-test"), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Join(localDirectory, "keyring-test"), os.ModePerm); err != nil {
 		return nil, err
 	}
 	tr := tar.NewReader(reader)

--- a/framework/docker/rollkit_node.go
+++ b/framework/docker/rollkit_node.go
@@ -34,7 +34,6 @@ var rollkitSentryPorts = nat.PortMap{
 type RollkitNode struct {
 	*node
 	cfg Config
-	log *zap.Logger
 	mu  sync.Mutex
 
 	GrpcConn *grpc.ClientConn
@@ -47,13 +46,13 @@ type RollkitNode struct {
 }
 
 func NewRollkitNode(cfg Config, testName string, image DockerImage, index int) *RollkitNode {
+	logger := cfg.Logger.With(
+		zap.Int("i", index),
+		zap.Bool("aggregator", index == 0),
+	)
 	rn := &RollkitNode{
-		log: cfg.Logger.With(
-			zap.Int("i", index),
-			zap.Bool("aggregator", index == 0),
-		),
 		cfg:  cfg,
-		node: newNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, "rollkit"),
+		node: newNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, "rollkit", logger),
 	}
 
 	rn.containerLifecycle = NewContainerLifecycle(cfg.Logger, cfg.DockerClient, rn.Name())

--- a/framework/testutil/config/config.go
+++ b/framework/testutil/config/config.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/BurntSushi/toml"
+	"path/filepath"
+	"strings"
+)
+
+// ReadWriter is an interface which ensures a type can both read and write configuration files.
+type ReadWriter interface {
+	// ReadFile reads the contents of the specified file from the given file path and returns it as a byte slice.
+	// An error is returned if the file cannot be accessed or read.
+	ReadFile(ctx context.Context, filePath string) ([]byte, error)
+	// WriteFile writes the given data to the specified file path. It returns an error if the write operation fails.
+	WriteFile(ctx context.Context, filePath string, data []byte) error
+}
+
+// Modify reads, modifies, then overwrites a config file, useful for config.toml, app.toml, etc.
+//
+// NOTE: when using this function, however the type is serialized will be what is written to disk.
+// if the struct is not specified in its entirety, some fields may be lost. In order to manipulate raw bytes
+// use *[]byte as the generic type.
+func Modify[T any](
+	ctx context.Context,
+	readWriter ReadWriter,
+	filePath string,
+	modification func(*T),
+) error {
+	configFileBz, err := readWriter.ReadFile(ctx, filePath)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve %s: %w", filePath, err)
+	}
+
+	var cfg T
+	if err := unmarshalByExtension(configFileBz, &cfg, filePath); err != nil {
+		return fmt.Errorf("failed to unmarshal %s: %w", filePath, err)
+	}
+
+	modification(&cfg)
+
+	bz, err := marshalByExtension(&cfg, filePath)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", filePath, err)
+	}
+
+	if err := readWriter.WriteFile(ctx, filePath, bz); err != nil {
+		return fmt.Errorf("failed to overwrite %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// unmarshalByExtension unmarshals data into the given config based on the file extension of configPath.
+func unmarshalByExtension(data []byte, config interface{}, configPath string) error {
+	// if we are dealing with raw bytes, we just return them as is.
+	// this use case is for if arbitrary modifications are required.
+	if _, ok := config.(*[]byte); ok {
+		return nil
+	}
+
+	switch filepath.Ext(configPath) {
+	case ".toml":
+		return toml.Unmarshal(data, config)
+	case ".json":
+		return json.Unmarshal(data, config)
+	default:
+		return fmt.Errorf("unsupported config file format: %s", configPath)
+	}
+}
+
+// marshalByExtension serializes the given data `v` into a byte slice based on the file extension of `filePath`.
+// It supports `.toml` and `.json` formats. If raw bytes are passed, it returns them directly.
+// returns an error if the file extension is unsupported or the serialization fails.
+func marshalByExtension(config interface{}, filePath string) ([]byte, error) {
+	// if we are dealing with raw bytes, we just return them as is.
+	// this use case is for if arbitrary modifications are required.
+	if byteSlice, ok := config.(*[]byte); ok {
+		return *byteSlice, nil
+	}
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".toml":
+		return toml.Marshal(config)
+	case ".json":
+		return json.MarshalIndent(config, "", "  ")
+	default:
+		return nil, fmt.Errorf("unsupported config file format: %s", ext)
+	}
+}

--- a/framework/testutil/config/config_test.go
+++ b/framework/testutil/config/config_test.go
@@ -1,0 +1,290 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mock implementation of ReadWriter for testing
+type mockReadWriter struct {
+	files map[string][]byte
+	mutex sync.RWMutex
+
+	// error injection for testing
+	readError  error
+	writeError error
+}
+
+func newMockReadWriter() *mockReadWriter {
+	return &mockReadWriter{
+		files: make(map[string][]byte),
+	}
+}
+
+func (m *mockReadWriter) ReadFile(ctx context.Context, filePath string) ([]byte, error) {
+	if m.readError != nil {
+		return nil, m.readError
+	}
+
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	data, exists := m.files[filePath]
+	if !exists {
+		return nil, fmt.Errorf("file not found: %s", filePath)
+	}
+	return data, nil
+}
+
+func (m *mockReadWriter) WriteFile(ctx context.Context, filePath string, data []byte) error {
+	if m.writeError != nil {
+		return m.writeError
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.files[filePath] = data
+	return nil
+}
+
+func (m *mockReadWriter) setFile(filePath string, content []byte) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.files[filePath] = content
+}
+
+func (m *mockReadWriter) getFile(filePath string) []byte {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return m.files[filePath]
+}
+
+// test config structs
+type SimpleConfig struct {
+	Name    string `json:"name" toml:"name"`
+	Port    int    `json:"port" toml:"port"`
+	Enabled bool   `json:"enabled" toml:"enabled"`
+}
+
+type AppConfig struct {
+	Name    string `json:"name" toml:"name"`
+	Version string `json:"version" toml:"version"`
+}
+
+type DatabaseConfig struct {
+	Host string `json:"host" toml:"host"`
+	Port int    `json:"port" toml:"port"`
+}
+
+type NestedConfig struct {
+	App      AppConfig      `json:"app" toml:"app"`
+	Database DatabaseConfig `json:"database" toml:"database"`
+}
+
+func TestModifySimpleJSON(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `{
+  "name": "test-app",
+  "port": 8080,
+  "enabled": true
+}`
+	mockRW.setFile("config.json", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "config.json", func(cfg *SimpleConfig) {
+		cfg.Name = "modified-app"
+		cfg.Port = 9090
+		cfg.Enabled = false
+	})
+
+	require.NoError(t, err)
+
+	var result SimpleConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("config.json"), &result, "config.json"))
+
+	require.Equal(t, "modified-app", result.Name)
+	require.Equal(t, 9090, result.Port)
+	require.Equal(t, false, result.Enabled)
+}
+
+func TestModifySimpleTOML(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `name = "test-app"
+port = 8080
+enabled = true
+`
+	mockRW.setFile("config.toml", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "config.toml", func(cfg *SimpleConfig) {
+		cfg.Name = "modified-toml-app"
+		cfg.Port = 3000
+	})
+
+	require.NoError(t, err)
+
+	var result SimpleConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("config.toml"), &result, "config.toml"))
+
+	require.Equal(t, "modified-toml-app", result.Name)
+	require.Equal(t, 3000, result.Port)
+	require.Equal(t, true, result.Enabled)
+}
+
+func TestModifyNestedJSON(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `{
+  "app": {
+    "name": "my-app",
+    "version": "1.0.0"
+  },
+  "database": {
+    "host": "localhost",
+    "port": 5432
+  }
+}`
+	mockRW.setFile("nested.json", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "nested.json", func(cfg *NestedConfig) {
+		cfg.App.Version = "2.0.0"
+		cfg.Database.Host = "remote-db"
+	})
+
+	require.NoError(t, err)
+
+	var result NestedConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("nested.json"), &result, "nested.json"))
+
+	require.Equal(t, "my-app", result.App.Name)
+	require.Equal(t, "2.0.0", result.App.Version)
+	require.Equal(t, "remote-db", result.Database.Host)
+	require.Equal(t, 5432, result.Database.Port)
+}
+
+func TestModifyNestedTOML(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `[app]
+name = "my-app"
+version = "1.0.0"
+
+[database]
+host = "localhost"
+port = 5432
+`
+	mockRW.setFile("nested.toml", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "nested.toml", func(cfg *NestedConfig) {
+		cfg.App.Name = "updated-app"
+		cfg.Database.Port = 3306
+	})
+
+	require.NoError(t, err)
+
+	var result NestedConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("nested.toml"), &result, "nested.toml"))
+
+	require.Equal(t, "updated-app", result.App.Name)
+	require.Equal(t, "1.0.0", result.App.Version)
+	require.Equal(t, "localhost", result.Database.Host)
+	require.Equal(t, 3306, result.Database.Port)
+}
+
+func TestModifyUnsupportedExtension(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	mockRW.setFile("config.xml", []byte(`<config></config>`))
+
+	err := Modify(ctx, mockRW, "config.xml", func(cfg *SimpleConfig) {
+		cfg.Name = "modified"
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported config file format")
+}
+
+func TestModifyInvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	invalidJSON := `{
+  "name": "test"
+  "invalid": json
+}`
+	mockRW.setFile("invalid.json", []byte(invalidJSON))
+
+	err := Modify(ctx, mockRW, "invalid.json", func(cfg *SimpleConfig) {
+		cfg.Name = "modified"
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal")
+}
+
+func TestModifyReadError(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+	mockRW.readError = errors.New("read failed")
+
+	err := Modify(ctx, mockRW, "test.json", func(cfg *SimpleConfig) {
+		cfg.Name = "modified"
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to retrieve")
+}
+
+func TestModifyWriteError(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+	mockRW.setFile("test.json", []byte(`{"name": "test", "port": 8080, "enabled": true}`))
+	mockRW.writeError = errors.New("write failed")
+
+	err := Modify(ctx, mockRW, "test.json", func(cfg *SimpleConfig) {
+		cfg.Name = "modified"
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "overwrite")
+}
+
+func TestModifyFileNotFound(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	err := Modify(ctx, mockRW, "nonexistent.json", func(cfg *SimpleConfig) {
+		cfg.Name = "modified"
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to retrieve")
+}
+
+func TestModifyRawBytes(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := []byte("original content that needs modification")
+	mockRW.setFile("raw.toml", initialContent)
+
+	err := Modify(ctx, mockRW, "raw.toml", func(data *[]byte) {
+		*data = []byte("modified raw content")
+	})
+
+	require.NoError(t, err)
+
+	result := mockRW.getFile("raw.toml")
+	require.Equal(t, []byte("modified raw content"), result)
+}

--- a/framework/types/chain.go
+++ b/framework/types/chain.go
@@ -49,4 +49,8 @@ type ChainNode interface {
 	GetInternalRPCAddress(ctx context.Context) (string, error)
 	// GetInternalHostName returns the hostname resolvable within the network.
 	GetInternalHostName(ctx context.Context) (string, error)
+	// ReadFile reads the contents of a file specified by a relative filePath and returns its byte data or an error on failure.
+	ReadFile(ctx context.Context, filePath string) ([]byte, error)
+	// WriteFile writes the provided byte data to the specified relative filePath. An error is returned if the write operation fails.
+	WriteFile(ctx context.Context, filePath string, data []byte) error
 }

--- a/framework/types/chain.go
+++ b/framework/types/chain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/celestiaorg/go-square/v2/share"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -53,4 +54,6 @@ type ChainNode interface {
 	ReadFile(ctx context.Context, filePath string) ([]byte, error)
 	// WriteFile writes the provided byte data to the specified relative filePath. An error is returned if the write operation fails.
 	WriteFile(ctx context.Context, filePath string, data []byte) error
+	// GetKeyring returns the keyring for this chain node.
+	GetKeyring() (keyring.Keyring, error)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR adds a new `dockerKeyring` implementation which is used to sign transactions
 on behalf of wallets created in the tests.

This is the first part of ensuring that tastora is compatible with the existing `TxClient` which depends on the `Keyring` interface [here](https://github.com/celestiaorg/celestia-app/blob/fff1649853640894f4b57ee176172aeb033ec302/pkg/user/signer.go#L33)

From celestia-app, we will be able to do something like `chain.GetNodes()[0].GetKeyring()` to access the keyring on the docker host, and will be able to use that at the GRPC connection to create `TxClient` instances and use the existing `user.NewSigner`.

closes #50

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
