### PR TITLE
feat: non-interactive init

### DIFF
--- a/framework/docker/chain_node.go
+++ b/framework/docker/chain_node.go
@@ -177,6 +177,7 @@ func (tn *ChainNode) initHomeFolder(ctx context.Context) error {
 	_, _, err := tn.execBin(ctx,
 		"init", CondenseMoniker(tn.Name()),
 		"--chain-id", tn.cfg.ChainConfig.ChainID,
+		"--yes", // bypass interactive prompt
 	)
 	return err
 }


### PR DESCRIPTION
## Overview

In  https://github.com/celestiaorg/celestia-app/pull/5024 we implemented interactive prompts for public network init, E2E tests need to handle that non-interactively

This PR aims at addressing that need, simply passing in the flag
