### PR TITLE
feat: update config marshalling to support mapstructure for toml files

### DIFF
--- a/framework/testutil/config/config.go
+++ b/framework/testutil/config/config.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/BurntSushi/toml"
+	"github.com/mitchellh/mapstructure"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -63,7 +66,24 @@ func unmarshalByExtension(data []byte, config interface{}, configPath string) er
 
 	switch filepath.Ext(configPath) {
 	case ".toml":
-		return toml.Unmarshal(data, config)
+		// the toml files like app.toml and config.toml use mapstructure annotations, not toml annotations.
+		// so we need to decode with the mapstructure library.
+		var tomlMap map[string]interface{}
+		if err := toml.Unmarshal(data, &tomlMap); err != nil {
+			return err
+		}
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+				mapstructure.StringToSliceHookFunc(","),
+				stringConversionHook(),
+			),
+			Result: config,
+		})
+		if err != nil {
+			return err
+		}
+		return decoder.Decode(tomlMap)
 	case ".json":
 		return json.Unmarshal(data, config)
 	default:
@@ -84,10 +104,67 @@ func marshalByExtension(config interface{}, filePath string) ([]byte, error) {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	switch ext {
 	case ".toml":
-		return toml.Marshal(config)
+		var tomlMap map[string]interface{}
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result: &tomlMap,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := decoder.Decode(config); err != nil {
+			return nil, err
+		}
+		return toml.Marshal(tomlMap)
 	case ".json":
 		return json.MarshalIndent(config, "", "  ")
 	default:
 		return nil, fmt.Errorf("unsupported config file format: %s", ext)
+	}
+}
+
+// stringConversionHook converts string values to int types for mapstructure
+// this is required as some values in the toml files are "2" and "true" and are not
+// parsable by default by mapstructure. This hook handles the conversion logic.
+func stringConversionHook() mapstructure.DecodeHookFunc {
+	return func(f, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+
+		str := data.(string)
+
+		switch t.Kind() {
+		case reflect.Int:
+			return strconv.Atoi(str)
+		case reflect.Int8:
+			val, err := strconv.ParseInt(str, 10, 8)
+			return int8(val), err
+		case reflect.Int16:
+			val, err := strconv.ParseInt(str, 10, 16)
+			return int16(val), err
+		case reflect.Int32:
+			val, err := strconv.ParseInt(str, 10, 32)
+			return int32(val), err
+		case reflect.Int64:
+			return strconv.ParseInt(str, 10, 64)
+		case reflect.Uint:
+			val, err := strconv.ParseUint(str, 10, 0)
+			return uint(val), err
+		case reflect.Uint8:
+			val, err := strconv.ParseUint(str, 10, 8)
+			return uint8(val), err
+		case reflect.Uint16:
+			val, err := strconv.ParseUint(str, 10, 16)
+			return uint16(val), err
+		case reflect.Uint32:
+			val, err := strconv.ParseUint(str, 10, 32)
+			return uint32(val), err
+		case reflect.Uint64:
+			return strconv.ParseUint(str, 10, 64)
+		case reflect.Bool:
+			return strconv.ParseBool(str)
+		default:
+			return data, nil
+		}
 	}
 }

--- a/framework/testutil/config/config_test.go
+++ b/framework/testutil/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,6 +86,35 @@ type DatabaseConfig struct {
 type NestedConfig struct {
 	App      AppConfig      `json:"app" toml:"app"`
 	Database DatabaseConfig `json:"database" toml:"database"`
+}
+
+// mapstructure-tagged config structs for testing real-world cosmos SDK config scenarios
+type MapstructureSimpleConfig struct {
+	Name    string `json:"name" mapstructure:"name"`
+	Port    int    `json:"port" mapstructure:"port"`
+	Enabled bool   `json:"enabled" mapstructure:"enabled"`
+}
+
+type MapstructureAppConfig struct {
+	Name    string `json:"name" mapstructure:"name"`
+	Version string `json:"version" mapstructure:"version"`
+}
+
+type MapstructureDatabaseConfig struct {
+	Host string `json:"host" mapstructure:"host"`
+	Port int    `json:"port" mapstructure:"port"`
+}
+
+type MapstructureNestedConfig struct {
+	App      MapstructureAppConfig      `json:"app" mapstructure:"app"`
+	Database MapstructureDatabaseConfig `json:"database" mapstructure:"database"`
+}
+
+// mixed tags config for testing precedence
+type MixedTagsConfig struct {
+	Name    string `json:"name" toml:"name_toml" mapstructure:"name"`
+	Port    int    `json:"port" toml:"port_toml" mapstructure:"port"`
+	Enabled bool   `json:"enabled" toml:"enabled_toml" mapstructure:"enabled"`
 }
 
 func TestModifySimpleJSON(t *testing.T) {
@@ -287,4 +317,189 @@ func TestModifyRawBytes(t *testing.T) {
 
 	result := mockRW.getFile("raw.toml")
 	require.Equal(t, []byte("modified raw content"), result)
+}
+
+// tests for mapstructure-tagged structs (real-world cosmos SDK config scenario)
+func TestModifySimpleTOMLWithMapstructureTags(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `name = "cosmos-app"
+port = 1317
+enabled = true
+`
+	mockRW.setFile("app.toml", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "app.toml", func(cfg *MapstructureSimpleConfig) {
+		cfg.Name = "modified-cosmos-app"
+		cfg.Port = 2317
+		cfg.Enabled = false
+	})
+
+	require.NoError(t, err)
+
+	var result MapstructureSimpleConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("app.toml"), &result, "app.toml"))
+
+	require.Equal(t, "modified-cosmos-app", result.Name)
+	require.Equal(t, 2317, result.Port)
+	require.Equal(t, false, result.Enabled)
+}
+
+func TestModifyNestedTOMLWithMapstructureTags(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `[app]
+name = "celestia-node"
+version = "1.0.0"
+
+[database]
+host = "localhost"
+port = 5432
+`
+	mockRW.setFile("config.toml", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "config.toml", func(cfg *MapstructureNestedConfig) {
+		cfg.App.Name = "updated-celestia-node"
+		cfg.App.Version = "2.0.0"
+		cfg.Database.Host = "remote-cosmos-db"
+		cfg.Database.Port = 3306
+	})
+
+	require.NoError(t, err)
+
+	var result MapstructureNestedConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("config.toml"), &result, "config.toml"))
+
+	require.Equal(t, "updated-celestia-node", result.App.Name)
+	require.Equal(t, "2.0.0", result.App.Version)
+	require.Equal(t, "remote-cosmos-db", result.Database.Host)
+	require.Equal(t, 3306, result.Database.Port)
+}
+
+func TestModifyJSONWithMapstructureTags(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	initialContent := `{
+  "name": "cosmos-json-app",
+  "port": 8080,
+  "enabled": true
+}`
+	mockRW.setFile("config.json", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "config.json", func(cfg *MapstructureSimpleConfig) {
+		cfg.Name = "modified-json-app"
+		cfg.Port = 9090
+		cfg.Enabled = false
+	})
+
+	require.NoError(t, err)
+
+	var result MapstructureSimpleConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("config.json"), &result, "config.json"))
+
+	require.Equal(t, "modified-json-app", result.Name)
+	require.Equal(t, 9090, result.Port)
+	require.Equal(t, false, result.Enabled)
+}
+
+// edge case tests
+func TestModifyMixedTags(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	// test that mapstructure tags take precedence in TOML files
+	initialContent := `name = "test-mixed"
+port = 8080
+enabled = true
+`
+	mockRW.setFile("mixed.toml", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "mixed.toml", func(cfg *MixedTagsConfig) {
+		cfg.Name = "modified-mixed"
+		cfg.Port = 9999
+		cfg.Enabled = false
+	})
+
+	require.NoError(t, err)
+
+	var result MixedTagsConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("mixed.toml"), &result, "mixed.toml"))
+
+	require.Equal(t, "modified-mixed", result.Name)
+	require.Equal(t, 9999, result.Port)
+	require.Equal(t, false, result.Enabled)
+}
+
+func TestModifyStringConversionHookWithMapstructure(t *testing.T) {
+	ctx := context.Background()
+	mockRW := newMockReadWriter()
+
+	// test the string conversion hook with quoted values in TOML
+	initialContent := `name = "string-conversion-test"
+port = "1317"
+enabled = "true"
+`
+	mockRW.setFile("conversion.toml", []byte(initialContent))
+
+	err := Modify(ctx, mockRW, "conversion.toml", func(cfg *MapstructureSimpleConfig) {
+		cfg.Port = 2317
+		cfg.Enabled = false
+	})
+
+	require.NoError(t, err)
+
+	var result MapstructureSimpleConfig
+	require.NoError(t, unmarshalByExtension(mockRW.getFile("conversion.toml"), &result, "conversion.toml"))
+
+	require.Equal(t, "string-conversion-test", result.Name)
+	require.Equal(t, 2317, result.Port)
+	require.Equal(t, false, result.Enabled)
+}
+
+// direct TOML marshalling/unmarshalling tests (bypassing the config system)
+func TestDirectTOMLMarshalUnmarshalWithTomlTags(t *testing.T) {
+	original := SimpleConfig{
+		Name:    "direct-toml-test",
+		Port:    8080,
+		Enabled: true,
+	}
+
+	// marshal using TOML library directly
+	tomlData, err := toml.Marshal(original)
+	require.NoError(t, err)
+
+	// unmarshal using TOML library directly
+	var result SimpleConfig
+	err = toml.Unmarshal(tomlData, &result)
+	require.NoError(t, err)
+
+	// verify round-trip works with toml tags
+	require.Equal(t, original.Name, result.Name)
+	require.Equal(t, original.Port, result.Port)
+	require.Equal(t, original.Enabled, result.Enabled)
+}
+
+func TestDirectTOMLMarshalUnmarshalWithMapstructureTags(t *testing.T) {
+	original := MapstructureSimpleConfig{
+		Name:    "direct-mapstructure-test",
+		Port:    9090,
+		Enabled: false,
+	}
+
+	// marshal using TOML library directly
+	tomlData, err := toml.Marshal(original)
+	require.NoError(t, err)
+
+	// unmarshal using TOML library directly
+	var result MapstructureSimpleConfig
+	err = toml.Unmarshal(tomlData, &result)
+	require.NoError(t, err)
+
+	// verify round-trip works (TOML library ignores mapstructure tags and uses field names)
+	require.Equal(t, original.Name, result.Name)
+	require.Equal(t, original.Port, result.Port)
+	require.Equal(t, original.Enabled, result.Enabled)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The cosmos sdk types are all annotated with the `mapstructure` annotation  e.g. like [this](https://github.com/celestiaorg/cosmos-sdk/blob/476f240203d1c8060ad17f224b8f7fb9cacd6a3b/server/config/config.go#L35)

which means in order to correctly marshal/unmarshal them to write config files it needs to be accounted for. This PR does make the assumption that **all** toml files are like this, which may not be true but I think is fine for now as realistically all we will be doing with this function is modifying sdk chain config files.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
