### PR TITLE
refactor: rename node to ContainerNode

### DIFF
--- a/framework/docker/chain_node.go
+++ b/framework/docker/chain_node.go
@@ -59,7 +59,7 @@ func (n *ChainNode) GetInternalRPCAddress(ctx context.Context) (string, error) {
 type ChainNodes []*ChainNode
 
 type ChainNode struct {
-	*node
+	*ContainerNode
 	cfg       Config
 	Validator bool
 	Client    rpcclient.Client
@@ -108,9 +108,9 @@ func NewDockerChainNode(log *zap.Logger, validator bool, cfg Config, testName st
 		zap.Int("i", index),
 	)
 	tn := &ChainNode{
-		Validator: validator,
-		cfg:       cfg,
-		node:      newNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var/cosmos-chain", cfg.ChainConfig.Name), index, nodeType, log),
+		Validator:     validator,
+		cfg:           cfg,
+		ContainerNode: newContainerNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var/cosmos-chain", cfg.ChainConfig.Name), index, nodeType, log),
 	}
 
 	tn.containerLifecycle = NewContainerLifecycle(log, cfg.DockerClient, tn.Name())

--- a/framework/docker/da_node.go
+++ b/framework/docker/da_node.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/celestiaorg/tastora/framework/docker/consts"
 	"github.com/celestiaorg/tastora/framework/testutil/toml"
 	"github.com/celestiaorg/tastora/framework/types"
-	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
 	"go.uber.org/zap"
 	"path"
@@ -40,44 +38,25 @@ func newDANode(ctx context.Context, testName string, cfg Config, idx int, nodeTy
 		zap.String("node_type", nodeType.String()),
 	)
 	daNode := &DANode{
-		cfg:      cfg,
-		nodeType: nodeType,
-		node:     newNode(cfg.DockerNetworkID, cfg.DockerClient, testName, defaultImage, "/home/celestia", idx, nodeType.String(), logger),
+		cfg:           cfg,
+		nodeType:      nodeType,
+		ContainerNode: newContainerNode(cfg.DockerNetworkID, cfg.DockerClient, testName, defaultImage, "/home/celestia", idx, nodeType.String(), logger),
 	}
 
 	daNode.containerLifecycle = NewContainerLifecycle(cfg.Logger, cfg.DockerClient, daNode.Name())
 
 	// image may be overridden by each node.
-	image := daNode.getImage()
-
-	v, err := cfg.DockerClient.VolumeCreate(ctx, volumetypes.CreateOptions{
-		Labels: map[string]string{
-			consts.CleanupLabel:   testName,
-			consts.NodeOwnerLabel: daNode.Name(),
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating volume for chain node: %w", err)
-	}
-	daNode.VolumeName = v.Name
-
-	if err := SetVolumeOwner(ctx, VolumeOwnerOptions{
-		Log:        daNode.logger,
-		Client:     cfg.DockerClient,
-		VolumeName: v.Name,
-		ImageRef:   image.Ref(),
-		TestName:   testName,
-		UidGid:     image.UIDGID,
-	}); err != nil {
-		return nil, fmt.Errorf("set volume owner: %w", err)
+	daNode.Image = daNode.getImage()
+	if err := daNode.createAndSetupVolume(ctx); err != nil {
+		return nil, fmt.Errorf("failed to create and setup volume: %w", err)
 	}
 
 	return daNode, nil
 }
 
-// DANode is a docker implementation of a celestia bridge node.
+// DANode is a docker implementation of a celestia da node.
 type DANode struct {
-	*node
+	*ContainerNode
 	cfg            Config
 	mu             sync.Mutex
 	hasBeenStarted bool
@@ -167,12 +146,12 @@ func (n *DANode) startAndInitialize(ctx context.Context, opts ...types.DANodeSta
 }
 
 // Name of the test node container.
-func (n *node) Name() string {
+func (n *ContainerNode) Name() string {
 	return fmt.Sprintf("%s-%d-%s", n.GetType(), n.Index, SanitizeContainerName(n.TestName))
 }
 
 // HostName of the test node container.
-func (n *node) HostName() string {
+func (n *ContainerNode) HostName() string {
 	return CondenseHostName(n.Name())
 }
 

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -18,7 +18,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	dockerimagetypes "github.com/docker/docker/api/types/image"
-	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -509,26 +508,8 @@ func (c *Chain) newChainNode(
 	// The ChainNode's VolumeName cannot be set until after we create the volume.
 	tn := NewDockerChainNode(c.log, validator, c.cfg, testName, image, index)
 
-	v, err := c.cfg.DockerClient.VolumeCreate(ctx, volumetypes.CreateOptions{
-		Labels: map[string]string{
-			consts.CleanupLabel:   testName,
-			consts.NodeOwnerLabel: tn.Name(),
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating volume for chain node: %w", err)
-	}
-	tn.VolumeName = v.Name
-
-	if err := SetVolumeOwner(ctx, VolumeOwnerOptions{
-		Log:        c.log,
-		Client:     c.cfg.DockerClient,
-		VolumeName: v.Name,
-		ImageRef:   image.Ref(),
-		TestName:   testName,
-		UidGid:     image.UIDGID,
-	}); err != nil {
-		return nil, fmt.Errorf("set volume owner: %w", err)
+	if err := tn.createAndSetupVolume(ctx); err != nil {
+		return nil, fmt.Errorf("creating and setting up volume for chain node: %w", err)
 	}
 
 	return tn, nil

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -140,13 +140,7 @@ func (c *Chain) AddNode(ctx context.Context, overrides map[string]any) error {
 // AddFullNodes adds new fullnodes to the network, peering with the existing nodes.
 func (c *Chain) AddFullNodes(ctx context.Context, configFileOverrides map[string]any, inc int) error {
 	// Get peer string for existing nodes
-
-	var peerAddressers []addressutil.PeerAddresser
-	for _, n := range c.Nodes() {
-		peerAddressers = append(peerAddressers, n)
-	}
-
-	peers, err := addressutil.BuildInternalPeerAddressList(ctx, peerAddressers)
+	peers, err := addressutil.BuildInternalPeerAddressList(ctx, c.Nodes())
 	if err != nil {
 		return err
 	}
@@ -380,12 +374,7 @@ func (c *Chain) startAndInitializeNodes(ctx context.Context) error {
 		return err
 	}
 
-	peerAddressers := make([]addressutil.PeerAddresser, len(chainNodes))
-	for i, n := range chainNodes {
-		peerAddressers[i] = n
-	}
-
-	peers, err := addressutil.BuildInternalPeerAddressList(ctx, peerAddressers)
+	peers, err := addressutil.BuildInternalPeerAddressList(ctx, chainNodes)
 	if err != nil {
 		return err
 	}

--- a/framework/docker/docker_node.go
+++ b/framework/docker/docker_node.go
@@ -3,13 +3,15 @@ package docker
 import (
 	"context"
 	"fmt"
+	"github.com/celestiaorg/tastora/framework/docker/consts"
 	"github.com/celestiaorg/tastora/framework/docker/file"
+	volumetypes "github.com/docker/docker/api/types/volume"
 	dockerclient "github.com/moby/moby/client"
 	"go.uber.org/zap"
 )
 
-// node contains the fields and shared methods for docker nodes. (app nodes & bridge nodes)
-type node struct {
+// ContainerNode contains the fields and shared methods for docker nodes. (app nodes & bridge nodes)
+type ContainerNode struct {
 	VolumeName         string
 	NetworkID          string
 	DockerClient       *dockerclient.Client
@@ -22,8 +24,8 @@ type node struct {
 	logger             *zap.Logger
 }
 
-// newNode creates a new node instance with the required parameters.
-func newNode(
+// newContainerNode creates a new ContainerNode instance with the required parameters.
+func newContainerNode(
 	networkID string,
 	dockerClient *dockerclient.Client,
 	testName string,
@@ -32,8 +34,8 @@ func newNode(
 	idx int,
 	nodeType string,
 	logger *zap.Logger,
-) *node {
-	return &node{
+) *ContainerNode {
+	return &ContainerNode{
 		NetworkID:    networkID,
 		DockerClient: dockerClient,
 		TestName:     testName,
@@ -46,7 +48,7 @@ func newNode(
 }
 
 // exec runs a command in the node's container.
-func (n *node) exec(ctx context.Context, logger *zap.Logger, cmd []string, env []string) ([]byte, []byte, error) {
+func (n *ContainerNode) exec(ctx context.Context, logger *zap.Logger, cmd []string, env []string) ([]byte, []byte, error) {
 	job := NewImage(logger, n.DockerClient, n.NetworkID, n.TestName, n.Image.Repository, n.Image.Version)
 	opts := ContainerOptions{
 		Env:   env,
@@ -59,33 +61,33 @@ func (n *node) exec(ctx context.Context, logger *zap.Logger, cmd []string, env [
 	return res.Stdout, res.Stderr, res.Err
 }
 
-// bind returns the home folder bind point for running the node.
-func (n *node) bind() []string {
+// bind returns the home folder bind point for running the ContainerNode.
+func (n *ContainerNode) bind() []string {
 	return []string{fmt.Sprintf("%s:%s", n.VolumeName, n.homeDir)}
 }
 
-// GetType returns the node type as a string.
-func (n *node) GetType() string {
+// GetType returns the ContainerNode type as a string.
+func (n *ContainerNode) GetType() string {
 	return n.nodeType
 }
 
-// removeContainer gracefully stops and removes the container associated with the node using the provided context.
-func (n *node) removeContainer(ctx context.Context) error {
+// removeContainer gracefully stops and removes the container associated with the ContainerNode using the provided context.
+func (n *ContainerNode) removeContainer(ctx context.Context) error {
 	return n.containerLifecycle.RemoveContainer(ctx)
 }
 
-// stopContainer gracefully stops the container associated with the node using the provided context.
-func (n *node) stopContainer(ctx context.Context) error {
+// stopContainer gracefully stops the container associated with the ContainerNode using the provided context.
+func (n *ContainerNode) stopContainer(ctx context.Context) error {
 	return n.containerLifecycle.StopContainer(ctx)
 }
 
-// startContainer starts the container associated with the node using the provided context.
-func (n *node) startContainer(ctx context.Context) error {
+// startContainer starts the container associated with the ContainerNode using the provided context.
+func (n *ContainerNode) startContainer(ctx context.Context) error {
 	return n.containerLifecycle.StartContainer(ctx)
 }
 
-// ReadFile reads a file from the node's container volume at the given relative path.
-func (n *node) ReadFile(ctx context.Context, relPath string) ([]byte, error) {
+// ReadFile reads a file from the ContainerNode's container volume at the given relative path.
+func (n *ContainerNode) ReadFile(ctx context.Context, relPath string) ([]byte, error) {
 	fr := file.NewRetriever(n.logger, n.DockerClient, n.TestName)
 	content, err := fr.SingleFileContent(ctx, n.VolumeName, relPath)
 	if err != nil {
@@ -97,7 +99,39 @@ func (n *node) ReadFile(ctx context.Context, relPath string) ([]byte, error) {
 // WriteFile accepts file contents in a byte slice and writes the contents to
 // the docker filesystem. relPath describes the location of the file in the
 // docker volume relative to the home directory.
-func (n *node) WriteFile(ctx context.Context, relPath string, content []byte) error {
+func (n *ContainerNode) WriteFile(ctx context.Context, relPath string, content []byte) error {
 	fw := file.NewWriter(n.logger, n.DockerClient, n.TestName)
 	return fw.WriteFile(ctx, n.VolumeName, relPath, content)
+}
+
+// createAndSetupVolume creates a Docker volume for the node and sets up proper ownership.
+// This consolidates the volume creation pattern used across all node types.
+func (n *ContainerNode) createAndSetupVolume(ctx context.Context) error {
+	// create volume with appropriate labels
+	v, err := n.DockerClient.VolumeCreate(ctx, volumetypes.CreateOptions{
+		Labels: map[string]string{
+			consts.CleanupLabel:   n.TestName,
+			consts.NodeOwnerLabel: n.Name(),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating volume for %s: %w", n.nodeType, err)
+	}
+
+	// set the node's volume name
+	n.VolumeName = v.Name
+
+	// configure volume ownership
+	if err := SetVolumeOwner(ctx, VolumeOwnerOptions{
+		Log:        n.logger,
+		Client:     n.DockerClient,
+		VolumeName: v.Name,
+		ImageRef:   n.Image.Ref(),
+		TestName:   n.TestName,
+		UidGid:     n.Image.UIDGID,
+	}); err != nil {
+		return fmt.Errorf("set volume owner: %w", err)
+	}
+
+	return nil
 }

--- a/framework/docker/rollkit_node.go
+++ b/framework/docker/rollkit_node.go
@@ -32,7 +32,7 @@ var rollkitSentryPorts = nat.PortMap{
 }
 
 type RollkitNode struct {
-	*node
+	*ContainerNode
 	cfg Config
 	mu  sync.Mutex
 
@@ -51,8 +51,8 @@ func NewRollkitNode(cfg Config, testName string, image DockerImage, index int) *
 		zap.Bool("aggregator", index == 0),
 	)
 	rn := &RollkitNode{
-		cfg:  cfg,
-		node: newNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, "rollkit", logger),
+		cfg:           cfg,
+		ContainerNode: newContainerNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, "rollkit", logger),
 	}
 
 	rn.containerLifecycle = NewContainerLifecycle(cfg.Logger, cfg.DockerClient, rn.Name())

--- a/framework/testutil/address/address.go
+++ b/framework/testutil/address/address.go
@@ -14,10 +14,10 @@ type PeerAddresser interface {
 
 // BuildInternalPeerAddressList constructs a comma-separated list of internal peer addresses from the given nodes.
 // It returns an error if any node fails to provide a peer address.
-func BuildInternalPeerAddressList(ctx context.Context, peer []PeerAddresser) (string, error) {
-	addrs := make([]string, 0, len(peer))
+func BuildInternalPeerAddressList[T PeerAddresser](ctx context.Context, peers []T) (string, error) {
+	addrs := make([]string, 0, len(peers))
 
-	for _, p := range peer {
+	for _, p := range peers {
 		addr, err := p.GetInternalPeerAddress(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get peer address from node of type %s: %w", p.GetType(), err)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR does a renaming of the `node` type to `ContainerNode` which is hopefully a little bit more clear in terms of what the type does, i.e. it is a base type for all of the types which are backed by containers (app,node,rollkit).

This PR also removes duplication in volume creation logic by also moving this into the `ContainerNode` type as it is the same everywhere.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
