### PR TITLE
feat: expose exec function for ChainNodes

### DIFF
--- a/framework/docker/chain_node.go
+++ b/framework/docker/chain_node.go
@@ -146,6 +146,12 @@ func (cn *ChainNode) Height(ctx context.Context) (int64, error) {
 	return height, nil
 }
 
+// Exec runs a command in the node's container.
+// returns stdout, stdin, and an error if one occurred.
+func (cn *ChainNode) Exec(ctx context.Context, cmd []string, env []string) ([]byte, []byte, error) {
+	return cn.exec(ctx, cn.logger(), cmd, env)
+}
+
 // initNodeFiles initializes essential file structures for a chain node by creating its home folder and setting configurations.
 func (cn *ChainNode) initNodeFiles(ctx context.Context) error {
 	if err := cn.initHomeFolder(ctx); err != nil {

--- a/framework/types/chain.go
+++ b/framework/types/chain.go
@@ -56,4 +56,6 @@ type ChainNode interface {
 	WriteFile(ctx context.Context, filePath string, data []byte) error
 	// GetKeyring returns the keyring for this chain node.
 	GetKeyring() (keyring.Keyring, error)
+	// Exec executes a command in the specified context with the given environment variables, returning stdout, stderr, and an error.
+	Exec(ctx context.Context, cmd []string, env []string) ([]byte, []byte, error)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Exposes the Exec function for use within tests when arbitrary commands need to be ran.

closes #65

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
