### PR TITLE
feat: add support for more granular node configurations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
   - specifically to these repos
     - https://github.com/celestiaorg/celestia-app
     - https://github.com/celestiaorg/celestia-node
-    - https://github.com/rollkit/rollkit
+    - https://github.com/evstack/ev-node
 
 ### Project Structure
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,58 @@ Tastora supports configurable internal ports for DA nodes, solving connectivity 
 
 This addresses the issue where celestia bridge nodes fail to start when trying to connect to hardcoded `localhost:26657` in multi-server setups.
 
+## Fine-Grained Wallet Control
+
+Tastora supports creating wallets on specific chain nodes, providing flexibility for testing scenarios that require granular control over wallet placement and key management.
+
+### Node-Specific Wallet Creation
+
+Create wallets on specific validators or full nodes:
+
+```go
+// Create wallet on a specific validator
+wallet1, err := chain.Validators[0].CreateWallet(ctx, "test-key-1", "celestia")
+if err != nil {
+    t.Fatal(err)
+}
+
+// Create wallet on a different validator
+wallet2, err := chain.Validators[1].CreateWallet(ctx, "test-key-2", "celestia") 
+if err != nil {
+    t.Fatal(err)
+}
+
+// Create wallet on a full node
+wallet3, err := chain.FullNodes[0].CreateWallet(ctx, "test-key-3", "celestia")
+if err != nil {
+    t.Fatal(err)
+}
+```
+
+### Faucet Wallet Access
+
+The faucet wallet is accessible on all validator nodes with automatically synchronized keys:
+
+```go
+// Access faucet wallet from any validator
+faucetWallet := chain.Validators[0].GetFaucetWallet()
+
+// Or from another validator - same wallet, synchronized keys
+faucetWallet2 := chain.Validators[1].GetFaucetWallet()
+
+// Chain-level access works (delegates to Validator[0])
+chainFaucetWallet := chain.GetFaucetWallet()
+```
+
+### Backward Compatibility
+
+Existing `chain.CreateWallet()` calls continue to work unchanged:
+
+```go
+// This works exactly as before
+wallet, err := chain.CreateWallet(ctx, "my-wallet")
+```
+
 ## Project Structure
 
 - `framework/` - Core framework code

--- a/framework/docker/chain_builder.go
+++ b/framework/docker/chain_builder.go
@@ -362,6 +362,16 @@ func (b *ChainBuilder) Build(ctx context.Context) (*Chain, error) {
 		return nil, fmt.Errorf("failed to initialize chain nodes: %w", err)
 	}
 
+	// separate validators and full nodes
+	var validators, fullNodes []*ChainNode
+	for _, node := range nodes {
+		if node.Validator {
+			validators = append(validators, node)
+		} else {
+			fullNodes = append(fullNodes, node)
+		}
+	}
+
 	chain := &Chain{
 		cfg: Config{
 			Logger:          b.logger,
@@ -385,7 +395,8 @@ func (b *ChainBuilder) Build(ctx context.Context) (*Chain, error) {
 			},
 		},
 		t:          b.t,
-		Validators: nodes,
+		Validators: validators,
+		FullNodes:  fullNodes,
 		cdc:        cdc,
 		log:        b.logger,
 	}

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -47,9 +47,8 @@ type Chain struct {
 	cdc        *codec.ProtoCodec
 	log        *zap.Logger
 
-	mu           sync.Mutex
-	faucetWallet types.Wallet
-	broadcaster  types.Broadcaster
+	mu          sync.Mutex
+	broadcaster types.Broadcaster
 
 	// started is a bool indicating if the Chain has been started or not.
 	// it is used to determine if files should be initialized at startup or
@@ -59,7 +58,7 @@ type Chain struct {
 
 // GetFaucetWallet retrieves the faucet wallet for the chain.
 func (c *Chain) GetFaucetWallet() types.Wallet {
-	return c.faucetWallet
+	return c.Validators[0].GetFaucetWallet()
 }
 
 // GetChainID returns the chain ID.
@@ -72,13 +71,13 @@ func (c *Chain) getBroadcaster() types.Broadcaster {
 	if c.broadcaster != nil {
 		return c.broadcaster
 	}
-	c.broadcaster = newBroadcaster(c.t, c)
+	c.broadcaster = newBroadcaster(c)
 	return c.broadcaster
 }
 
 // BroadcastMessages broadcasts the given messages signed on behalf of the provided user.
 func (c *Chain) BroadcastMessages(ctx context.Context, signingWallet types.Wallet, msgs ...sdk.Msg) (sdk.TxResponse, error) {
-	if c.faucetWallet.GetFormattedAddress() == "" {
+	if c.GetFaucetWallet() == nil {
 		return sdk.TxResponse{}, fmt.Errorf("faucet wallet not initialized")
 	}
 	return c.getBroadcaster().BroadcastMessages(ctx, signingWallet, msgs...)
@@ -294,7 +293,19 @@ func (c *Chain) startAndInitializeNodes(ctx context.Context) error {
 	}
 
 	// Wait for blocks before considering the chains "started"
-	return wait.ForBlocks(ctx, 2, c.GetNode())
+	if err := wait.ForBlocks(ctx, 2, c.GetNode()); err != nil {
+		return err
+	}
+
+	// copy faucet key to all other validators now that containers are running
+	for i := 1; i < len(c.Validators); i++ {
+		if err := c.copyFaucetKeyToValidator(ctx, c.Validators[i]); err != nil {
+			return fmt.Errorf("failed to copy faucet key to validator %d: %w", i, err)
+		}
+		c.Validators[i].faucetWallet = c.Validators[0].faucetWallet
+	}
+
+	return nil
 }
 
 // initDefaultGenesis initializes the default genesis file with validators and a faucet account for funding test wallets.
@@ -323,7 +334,7 @@ func (c *Chain) initDefaultGenesis(ctx context.Context, defaultGenesisAmount sdk
 	if err != nil {
 		return nil, fmt.Errorf("failed to create faucet wallet: %w", err)
 	}
-	c.faucetWallet = wallet
+	c.Validators[0].faucetWallet = wallet
 
 	if err := validator0.addGenesisAccount(ctx, wallet.GetFormattedAddress(), []sdk.Coin{{Denom: c.cfg.ChainConfig.Denom, Amount: sdkmath.NewInt(10_000_000_000_000)}}); err != nil {
 		return nil, err
@@ -421,31 +432,37 @@ func (c *Chain) pullImages(ctx context.Context) {
 	}
 }
 
-// CreateWallet will creates a new wallet.
+// CreateWallet creates a new wallet using Validator[0] to maintain backward compatibility.
 func (c *Chain) CreateWallet(ctx context.Context, keyName string) (types.Wallet, error) {
-	if err := c.createKey(ctx, keyName); err != nil {
-		return nil, fmt.Errorf("failed to create key with name %q on chain %s: %w", keyName, c.cfg.ChainConfig.Name, err)
-	}
-
-	addrBytes, err := c.getAddress(ctx, keyName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get account address for key %q on chain %s: %w", keyName, c.cfg.ChainConfig.Name, err)
-	}
-
-	formattedAddres := sdk.MustBech32ifyAddressBytes(c.cfg.ChainConfig.Bech32Prefix, addrBytes)
-
-	w := NewWallet(addrBytes, formattedAddres, c.cfg.ChainConfig.Bech32Prefix, keyName)
-	return &w, nil
+	return c.GetNode().CreateWallet(ctx, keyName, c.cfg.ChainConfig.Bech32Prefix)
 }
 
-func (c *Chain) createKey(ctx context.Context, keyName string) error {
-	return c.GetNode().createKey(ctx, keyName)
-}
+// copyFaucetKeyToValidator copies the faucet key from validator[0] to the specified validator.
+func (c *Chain) copyFaucetKeyToValidator(ctx context.Context, targetValidator *ChainNode) error {
+	faucetKeyName := consts.FaucetAccountKeyName
 
-func (c *Chain) getAddress(ctx context.Context, keyName string) ([]byte, error) {
-	b32Addr, err := c.GetNode().accountKeyBech32(ctx, keyName)
+	// get the keyring from validator[0] (source)
+	sourceKeyring, err := c.Validators[0].GetKeyring()
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to get source keyring: %w", err)
 	}
-	return sdk.GetFromBech32(b32Addr, c.cfg.ChainConfig.Bech32Prefix)
+
+	// get the keyring from target validator
+	targetKeyring, err := targetValidator.GetKeyring()
+	if err != nil {
+		return fmt.Errorf("failed to get target keyring: %w", err)
+	}
+
+	// export the key from source
+	armoredKey, err := sourceKeyring.ExportPrivKeyArmor(faucetKeyName, "")
+	if err != nil {
+		return fmt.Errorf("failed to export faucet key: %w", err)
+	}
+
+	// import the key to target
+	if err := targetKeyring.ImportPrivKey(faucetKeyName, armoredKey, ""); err != nil {
+		return fmt.Errorf("failed to import faucet key: %w", err)
+	}
+
+	return nil
 }

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -297,9 +297,10 @@ func (c *Chain) startAndInitializeNodes(ctx context.Context) error {
 		return err
 	}
 
-	// copy faucet key to all other validators now that containers are running
+	// copy faucet key to all other validators now that containers are running.
+	// this ensures the faucet wallet can be used on all nodes.
 	for i := 1; i < len(c.Validators); i++ {
-		if err := c.copyFaucetKeyToValidator(ctx, c.Validators[i]); err != nil {
+		if err := c.copyFaucetKeyToValidator(c.Validators[i]); err != nil {
 			return fmt.Errorf("failed to copy faucet key to validator %d: %w", i, err)
 		}
 		c.Validators[i].faucetWallet = c.Validators[0].faucetWallet
@@ -438,10 +439,10 @@ func (c *Chain) CreateWallet(ctx context.Context, keyName string) (types.Wallet,
 }
 
 // copyFaucetKeyToValidator copies the faucet key from validator[0] to the specified validator.
-func (c *Chain) copyFaucetKeyToValidator(ctx context.Context, targetValidator *ChainNode) error {
+func (c *Chain) copyFaucetKeyToValidator(targetValidator *ChainNode) error {
 	faucetKeyName := consts.FaucetAccountKeyName
 
-	// get the keyring from validator[0] (source)
+	// as part of setup, the faucet wallet was created on Validators[0]
 	sourceKeyring, err := c.Validators[0].GetKeyring()
 	if err != nil {
 		return fmt.Errorf("failed to get source keyring: %w", err)

--- a/framework/docker/docker_test.go
+++ b/framework/docker/docker_test.go
@@ -93,7 +93,7 @@ func (s *DockerTestSuite) CreateDockerProvider(opts ...ConfigOption) *Provider {
 			AggregatorPassphrase: "12345678",
 			NumNodes:             1,
 			Image: container.Image{
-				Repository: "ghcr.io/rollkit/rollkit",
+				Repository: "ghcr.io/evstack/rollkit",
 				Version:    "main",
 				UIDGID:     "2000",
 			},

--- a/framework/docker/docker_test.go
+++ b/framework/docker/docker_test.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"github.com/celestiaorg/tastora/framework/docker/container"
-	"github.com/celestiaorg/tastora/framework/types"
 	"github.com/moby/moby/client"
 	"testing"
 
@@ -25,7 +24,7 @@ type DockerTestSuite struct {
 	logger       *zap.Logger
 	encConfig    testutil.TestEncodingConfig
 	provider     *Provider
-	chain        types.Chain
+	chain        *Chain
 	builder      *ChainBuilder
 }
 

--- a/framework/docker/docker_wallet_test.go
+++ b/framework/docker/docker_wallet_test.go
@@ -1,0 +1,132 @@
+package docker
+
+import (
+	"cosmossdk.io/math"
+	"github.com/celestiaorg/tastora/framework/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+// TestCreateWalletOnSpecificNode tests wallet creation on specific nodes.
+func (s *DockerTestSuite) TestCreateWalletOnSpecificNode() {
+	// create chain with 2 validators and 1 full node
+	s.builder = s.builder.WithNodes(
+		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(FullNodeType).Build(),
+	)
+
+	var err error
+	s.chain, err = s.builder.Build(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(s.ctx)
+	s.Require().NoError(err)
+
+	// get typed chain for accessing Validators and FullNodes
+	dockerChain := s.chain.(*Chain)
+
+	// test creating wallet on validator[0]
+	wallet1, err := dockerChain.Validators[0].CreateWallet(s.ctx, "test-key-1", dockerChain.cfg.ChainConfig.Bech32Prefix)
+	s.Require().NoError(err)
+	s.Require().NotNil(wallet1)
+	s.Require().Equal("test-key-1", wallet1.GetKeyName())
+	s.Require().NotEmpty(wallet1.GetFormattedAddress())
+
+	// test creating wallet on validator[1]
+	wallet2, err := dockerChain.Validators[1].CreateWallet(s.ctx, "test-key-2", dockerChain.cfg.ChainConfig.Bech32Prefix)
+	s.Require().NoError(err)
+	s.Require().NotNil(wallet2)
+	s.Require().Equal("test-key-2", wallet2.GetKeyName())
+	s.Require().NotEmpty(wallet2.GetFormattedAddress())
+
+	// wallets should have different addresses
+	s.Require().NotEqual(wallet1.GetFormattedAddress(), wallet2.GetFormattedAddress())
+
+	// test creating wallet on full node
+	wallet3, err := dockerChain.FullNodes[0].CreateWallet(s.ctx, "test-key-3", dockerChain.cfg.ChainConfig.Bech32Prefix)
+	s.Require().NoError(err)
+	s.Require().NotNil(wallet3)
+	s.Require().Equal("test-key-3", wallet3.GetKeyName())
+	s.Require().NotEmpty(wallet3.GetFormattedAddress())
+}
+
+// TestGetFaucetWalletOnNodes tests faucet wallet accessibility on all nodes.
+func (s *DockerTestSuite) TestGetFaucetWalletOnNodes() {
+	// create chain with 2 validators
+	s.builder = s.builder.WithNodes(
+		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
+	)
+
+	var err error
+	s.chain, err = s.builder.Build(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(s.ctx)
+	s.Require().NoError(err)
+
+	// get typed chain for accessing Validators
+	dockerChain := s.chain.(*Chain)
+
+	// faucet wallet should be available on all validators
+	faucetWallet1 := dockerChain.Validators[0].GetFaucetWallet()
+	s.Require().NotNil(faucetWallet1)
+	s.Require().NotEmpty(faucetWallet1.GetFormattedAddress())
+
+	faucetWallet2 := dockerChain.Validators[1].GetFaucetWallet()
+	s.Require().NotNil(faucetWallet2)
+	s.Require().Equal(faucetWallet1.GetFormattedAddress(), faucetWallet2.GetFormattedAddress())
+
+	// chain's GetFaucetWallet should return same as validator[0]
+	chainFaucetWallet := s.chain.GetFaucetWallet()
+	s.Require().Equal(faucetWallet1.GetFormattedAddress(), chainFaucetWallet.GetFormattedAddress())
+
+	// verify faucet wallet can be used for broadcasting transactions on each node
+	// create a test recipient wallet
+	testWallet, err := dockerChain.Validators[0].CreateWallet(s.ctx, "test-recipient", dockerChain.cfg.ChainConfig.Bech32Prefix)
+	s.Require().NoError(err)
+
+	// test broadcasting from validator[0] using faucet wallet
+	err = s.testFaucetBroadcast(dockerChain.Validators[0], faucetWallet1, testWallet)
+	s.Require().NoError(err)
+
+	// test broadcasting from validator[1] using faucet wallet
+	err = s.testFaucetBroadcast(dockerChain.Validators[1], faucetWallet2, testWallet)
+	s.Require().NoError(err)
+}
+
+// TestCreateWalletBackwardCompatibility tests that existing Chain.CreateWallet still works.
+func (s *DockerTestSuite) TestCreateWalletBackwardCompatibility() {
+	var err error
+	s.chain, err = s.builder.Build(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.chain.Start(s.ctx)
+	s.Require().NoError(err)
+
+	// existing Chain.CreateWallet should still work
+	wallet, err := s.chain.CreateWallet(s.ctx, "test-wallet")
+	s.Require().NoError(err)
+	s.Require().NotNil(wallet)
+	s.Require().Equal("test-wallet", wallet.GetKeyName())
+	s.Require().NotEmpty(wallet.GetFormattedAddress())
+}
+
+// testFaucetBroadcast helper function to test broadcasting a bank send transaction using the faucet wallet on a specific node
+func (s *DockerTestSuite) testFaucetBroadcast(node *ChainNode, faucetWallet, recipientWallet types.Wallet) error {
+	// create a bank send message
+	sendAmount := sdk.NewCoins(sdk.NewCoin(s.chain.(*Chain).cfg.ChainConfig.Denom, math.NewInt(1000)))
+	msg := &banktypes.MsgSend{
+		FromAddress: faucetWallet.GetFormattedAddress(),
+		ToAddress:   recipientWallet.GetFormattedAddress(),
+		Amount:      sendAmount,
+	}
+
+	// get a broadcaster that will broadcast through the specific node
+	broadcaster := node.GetBroadcaster(s.chain.(*Chain))
+	
+	// broadcast the transaction using the node-specific broadcaster
+	_, err := broadcaster.BroadcastMessages(s.ctx, faucetWallet, msg)
+	return err
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

In order to do some more fine grained testing, it is necessary to be able to manage keys / broadcast transactions at a per node basis.

This PR adds support for that but continues to just pass through to `Validators[0]` when interacting with the chain directly.

closes #83

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
