### PR TITLE
refactor: nodetypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
 CLAUDE.local.md
+memory-bank/

--- a/framework/docker/container/node.go
+++ b/framework/docker/container/node.go
@@ -3,9 +3,11 @@ package container
 import (
 	"context"
 	"fmt"
+
 	"github.com/celestiaorg/tastora/framework/docker/consts"
 	"github.com/celestiaorg/tastora/framework/docker/file"
 	"github.com/celestiaorg/tastora/framework/docker/volume"
+	"github.com/celestiaorg/tastora/framework/types"
 	"github.com/docker/docker/api/types/mount"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
@@ -22,7 +24,7 @@ type Node struct {
 	Image              Image
 	ContainerLifecycle *Lifecycle
 	homeDir            string
-	nodeType           string
+	nodeType           types.NodeType
 	Index              int
 	Logger             *zap.Logger
 }
@@ -35,7 +37,7 @@ func NewNode(
 	image Image,
 	homeDir string,
 	idx int,
-	nodeType string,
+	nodeType types.NodeType,
 	logger *zap.Logger,
 ) *Node {
 	return &Node{
@@ -79,8 +81,8 @@ func (n *Node) Bind() []string {
 	return []string{fmt.Sprintf("%s:%s", n.VolumeName, n.homeDir)}
 }
 
-// GetType returns the Node type as a string.
-func (n *Node) GetType() string {
+// GetType returns the Node type.
+func (n *Node) GetType() types.NodeType {
 	return n.nodeType
 }
 
@@ -144,7 +146,7 @@ func (n *Node) CreateAndSetupVolume(ctx context.Context, nodeName string) error 
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("creating volume for %s: %w", n.nodeType, err)
+		return fmt.Errorf("creating volume for %s: %w", n.nodeType.String(), err)
 	}
 
 	n.VolumeName = v.Name

--- a/framework/docker/da_network.go
+++ b/framework/docker/da_network.go
@@ -3,8 +3,9 @@ package docker
 import (
 	"context"
 	"fmt"
-	"github.com/celestiaorg/tastora/framework/types"
 	"sync"
+
+	"github.com/celestiaorg/tastora/framework/types"
 )
 
 var _ types.DataAvailabilityNetwork = &DataAvailabilityNetwork{}

--- a/framework/docker/da_node.go
+++ b/framework/docker/da_node.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/celestiaorg/tastora/framework/docker/container"
-	"github.com/celestiaorg/tastora/framework/docker/internal"
 	"path"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/celestiaorg/tastora/framework/docker/container"
+	"github.com/celestiaorg/tastora/framework/docker/internal"
 
 	"github.com/celestiaorg/tastora/framework/testutil/toml"
 	"github.com/celestiaorg/tastora/framework/types"
@@ -41,7 +42,7 @@ func newDANode(ctx context.Context, testName string, cfg Config, idx int, nodeTy
 	daNode := &DANode{
 		cfg:      cfg,
 		nodeType: nodeType,
-		Node:     container.NewNode(cfg.DockerNetworkID, cfg.DockerClient, testName, defaultImage, "/home/celestia", idx, nodeType.String(), logger),
+		Node:     container.NewNode(cfg.DockerNetworkID, cfg.DockerClient, testName, defaultImage, "/home/celestia", idx, nodeType, logger),
 	}
 
 	daNode.SetContainerLifecycle(container.NewLifecycle(cfg.Logger, cfg.DockerClient, daNode.Name()))

--- a/framework/docker/da_node_ports_test.go
+++ b/framework/docker/da_node_ports_test.go
@@ -72,7 +72,8 @@ func TestDANodePortConfiguration(t *testing.T) {
 		}
 
 		daNode := &DANode{
-			cfg: cfg,
+			cfg:      cfg,
+			nodeType: types.BridgeNode,
 			Node: &container.Node{
 				Index: 0,
 			},

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -99,7 +99,7 @@ func (c *Chain) BroadcastBlobMessage(ctx context.Context, signingWallet types.Wa
 func (c *Chain) AddNode(ctx context.Context, nodeConfig ChainNodeConfig) error {
 	if nodeConfig.nodeType != types.NodeTypeConsensusFull {
 		// TODO: this is preserving existing functionality, we can update this to support addition of validator nodes.
-		return fmt.Errorf("node type must be %s", types.NodeTypeConsensusFull)
+		return fmt.Errorf("node type must be %s", types.NodeTypeConsensusFull.String())
 	}
 
 	// get genesis.json

--- a/framework/docker/docker_chain.go
+++ b/framework/docker/docker_chain.go
@@ -3,8 +3,12 @@ package docker
 import (
 	"bytes"
 	"context"
-	sdkmath "cosmossdk.io/math"
 	"fmt"
+	"io"
+	"sync"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/go-square/v2/share"
 	"github.com/celestiaorg/tastora/framework/docker/consts"
 	addressutil "github.com/celestiaorg/tastora/framework/testutil/address"
@@ -16,9 +20,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"io"
-	"sync"
-	"testing"
 )
 
 var _ types.Chain = &Chain{}
@@ -30,14 +31,6 @@ var sentryPorts = nat.PortMap{
 	nat.Port(apiPort):     {},
 	nat.Port(privValPort): {},
 }
-
-// NodeType represents the type of blockchain node
-type NodeType int
-
-const (
-	ValidatorNodeType NodeType = iota
-	FullNodeType
-)
 
 type Chain struct {
 	t          *testing.T
@@ -104,9 +97,9 @@ func (c *Chain) BroadcastBlobMessage(ctx context.Context, signingWallet types.Wa
 
 // AddNode adds a single full node to the chain with the given configuration
 func (c *Chain) AddNode(ctx context.Context, nodeConfig ChainNodeConfig) error {
-	if nodeConfig.nodeType != FullNodeType {
+	if nodeConfig.nodeType != types.NodeTypeConsensusFull {
 		// TODO: this is preserving existing functionality, we can update this to support addition of validator nodes.
-		return fmt.Errorf("node type must be FullNodeType")
+		return fmt.Errorf("node type must be %s", types.NodeTypeConsensusFull)
 	}
 
 	// get genesis.json

--- a/framework/docker/docker_wallet_test.go
+++ b/framework/docker/docker_wallet_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"cosmossdk.io/math"
+
 	"github.com/celestiaorg/tastora/framework/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -11,9 +12,9 @@ import (
 func (s *DockerTestSuite) TestCreateWalletOnSpecificNode() {
 	// create chain with 2 validators and 1 full node
 	s.builder = s.builder.WithNodes(
-		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
-		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
-		NewChainNodeConfigBuilder().WithNodeType(FullNodeType).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(types.NodeTypeValidator).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(types.NodeTypeValidator).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(types.NodeTypeConsensusFull).Build(),
 	)
 
 	var err error
@@ -52,8 +53,8 @@ func (s *DockerTestSuite) TestCreateWalletOnSpecificNode() {
 func (s *DockerTestSuite) TestGetFaucetWalletOnNodes() {
 	// create chain with 2 validators
 	s.builder = s.builder.WithNodes(
-		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
-		NewChainNodeConfigBuilder().WithNodeType(ValidatorNodeType).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(types.NodeTypeValidator).Build(),
+		NewChainNodeConfigBuilder().WithNodeType(types.NodeTypeValidator).Build(),
 	)
 
 	var err error

--- a/framework/docker/ibc/relayer/hermes.go
+++ b/framework/docker/ibc/relayer/hermes.go
@@ -50,7 +50,7 @@ func NewHermes(ctx context.Context, dockerClient *dockerclient.Client, testName,
 		image,
 		hermesHomeDir,
 		index,
-		"hermes-relayer",
+		types.NodeTypeHermes,
 		logger,
 	)
 

--- a/framework/docker/ibc/relayer/hermes.go
+++ b/framework/docker/ibc/relayer/hermes.go
@@ -50,7 +50,7 @@ func NewHermes(ctx context.Context, dockerClient *dockerclient.Client, testName,
 		image,
 		hermesHomeDir,
 		index,
-		types.NodeTypeHermes,
+		HermesRelayer,
 		logger,
 	)
 

--- a/framework/docker/ibc/relayer/node_type.go
+++ b/framework/docker/ibc/relayer/node_type.go
@@ -1,5 +1,7 @@
 package relayer
 
+import "github.com/celestiaorg/tastora/framework/types"
+
 // HermesNodeType represents a Hermes IBC relayer node
 type HermesNodeType struct{}
 
@@ -12,4 +14,4 @@ func (h HermesNodeType) String() string {
 var HermesRelayer = HermesNodeType{}
 
 // Interface Compliance Check - ensure HermesNodeType implements the NodeType interface
-var _ interface{ String() string } = HermesRelayer
+var _ types.NodeType = (*HermesNodeType)(nil)

--- a/framework/docker/ibc/relayer/node_type.go
+++ b/framework/docker/ibc/relayer/node_type.go
@@ -1,0 +1,15 @@
+package relayer
+
+// HermesNodeType represents a Hermes IBC relayer node
+type HermesNodeType struct{}
+
+// String returns the string representation of the HermesNodeType
+func (h HermesNodeType) String() string {
+	return "hermes"
+}
+
+// HermesRelayer is the singleton instance representing a Hermes IBC relayer node
+var HermesRelayer = HermesNodeType{}
+
+// Interface Compliance Check - ensure HermesNodeType implements the NodeType interface
+var _ interface{ String() string } = HermesRelayer

--- a/framework/docker/rollkit_node.go
+++ b/framework/docker/rollkit_node.go
@@ -59,7 +59,7 @@ func NewRollkitNode(cfg Config, testName string, image container.Image, index in
 	)
 	rn := &RollkitNode{
 		cfg:  cfg,
-		Node: container.NewNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, types.NodeTypeRollkit, logger),
+		Node: container.NewNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, RollkitType, logger),
 	}
 
 	rn.SetContainerLifecycle(container.NewLifecycle(cfg.Logger, cfg.DockerClient, rn.Name()))

--- a/framework/docker/rollkit_node.go
+++ b/framework/docker/rollkit_node.go
@@ -58,8 +58,8 @@ func NewRollkitNode(cfg Config, testName string, image container.Image, index in
 		zap.Bool("aggregator", index == 0),
 	)
 	rn := &RollkitNode{
-		cfg:           cfg,
-		Node: container.NewNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, "rollkit", logger),
+		cfg:  cfg,
+		Node: container.NewNode(cfg.DockerNetworkID, cfg.DockerClient, testName, image, path.Join("/var", "rollkit"), index, types.NodeTypeRollkit, logger),
 	}
 
 	rn.SetContainerLifecycle(container.NewLifecycle(cfg.Logger, cfg.DockerClient, rn.Name()))

--- a/framework/docker/rollkit_node_type.go
+++ b/framework/docker/rollkit_node_type.go
@@ -1,5 +1,7 @@
 package docker
 
+import "github.com/celestiaorg/tastora/framework/types"
+
 // RollkitNodeType represents a Rollkit node
 type RollkitNodeType struct{}
 
@@ -12,4 +14,4 @@ func (r RollkitNodeType) String() string {
 var RollkitType = RollkitNodeType{}
 
 // Interface Compliance Check - ensure RollkitNodeType implements the NodeType interface
-var _ interface{ String() string } = RollkitType
+var _ types.NodeType = (*RollkitNodeType)(nil)

--- a/framework/docker/rollkit_node_type.go
+++ b/framework/docker/rollkit_node_type.go
@@ -1,0 +1,15 @@
+package docker
+
+// RollkitNodeType represents a Rollkit node
+type RollkitNodeType struct{}
+
+// String returns the string representation of the RollkitNodeType
+func (r RollkitNodeType) String() string {
+	return "rollkit"
+}
+
+// RollkitType is the singleton instance representing a Rollkit node
+var RollkitType = RollkitNodeType{}
+
+// Interface Compliance Check - ensure RollkitNodeType implements the NodeType interface
+var _ interface{ String() string } = RollkitType

--- a/framework/testutil/address/address.go
+++ b/framework/testutil/address/address.go
@@ -3,13 +3,14 @@ package address
 import (
 	"context"
 	"fmt"
-	"github.com/celestiaorg/tastora/framework/types"
 	"strings"
+
+	"github.com/celestiaorg/tastora/framework/types"
 )
 
 type PeerAddresser interface {
 	GetInternalPeerAddress(ctx context.Context) (string, error)
-	GetType() string
+	GetType() types.ConsensusNodeType
 }
 
 // BuildInternalPeerAddressList constructs a comma-separated list of internal peer addresses from the given nodes.
@@ -20,7 +21,7 @@ func BuildInternalPeerAddressList[T PeerAddresser](ctx context.Context, peers []
 	for _, p := range peers {
 		addr, err := p.GetInternalPeerAddress(ctx)
 		if err != nil {
-			return "", fmt.Errorf("failed to get peer address from node of type %s: %w", p.GetType(), err)
+			return "", fmt.Errorf("failed to get peer address from node of type %s: %w", p.GetType().String(), err)
 		}
 		addrs = append(addrs, addr)
 	}
@@ -35,7 +36,7 @@ func BuildInternalRPCAddressList(ctx context.Context, nodes []types.ChainNode) (
 	for _, node := range nodes {
 		addr, err := node.GetInternalRPCAddress(ctx)
 		if err != nil {
-			return "", fmt.Errorf("failed to get rpc address from node of type %s: %w", node.GetType(), err)
+			return "", fmt.Errorf("failed to get rpc address from node of type %s: %w", node.GetType().String(), err)
 		}
 		addrs = append(addrs, addr)
 	}

--- a/framework/types/chain.go
+++ b/framework/types/chain.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"context"
+
 	"github.com/celestiaorg/go-square/v2/share"
+
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -50,8 +52,8 @@ type Chain interface {
 }
 
 type ChainNode interface {
-	// GetType returns if the node is a fullnode or a validator. "fn" or a "val"
-	GetType() string
+	// GetType returns if the node is a fullnode or a validator. NodeTypeConsensusFull or NodeTypeValidator
+	GetType() ConsensusNodeType
 	// GetRPCClient retrieves the RPC client associated with the chain node, returning the client instance or an error.
 	GetRPCClient() (rpcclient.Client, error)
 	// GetInternalPeerAddress returns the peer address resolvable within the network.

--- a/framework/types/da_node.go
+++ b/framework/types/da_node.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/celestiaorg/go-square/v2/share"
+
 	"github.com/celestiaorg/tastora/framework/testutil/toml"
 )
 
@@ -49,24 +50,6 @@ func extractFirstTCPv4Addr(addrs []string) (string, error) {
 
 type Header struct {
 	Height uint64 `json:"height"`
-}
-
-type DANodeType int
-
-const (
-	BridgeNode DANodeType = iota
-	LightNode
-	FullNode
-)
-
-func (n DANodeType) String() string {
-	return nodeStrings[n]
-}
-
-var nodeStrings = [...]string{
-	"bridge",
-	"light",
-	"full",
 }
 
 type DANode interface {

--- a/framework/types/node.go
+++ b/framework/types/node.go
@@ -1,0 +1,79 @@
+package types
+
+// NodeType represents any node type that can be converted to a string
+type NodeType interface {
+	String() string
+}
+
+// Consensus Node Types (Celestia blockchain consensus)
+
+// ConsensusNodeType represents nodes that participate in Celestia consensus
+type ConsensusNodeType int
+
+const (
+	// Celestia Chain Node Types (CometBFT consensus)
+	NodeTypeValidator     ConsensusNodeType = iota // Validator node in blockchain
+	NodeTypeConsensusFull                          // Full node in blockchain
+)
+
+// String returns the string representation of the ConsensusNodeType
+func (n ConsensusNodeType) String() string {
+	return consensusNodeTypeStrings[n]
+}
+
+var consensusNodeTypeStrings = [...]string{
+	"validator",      // NodeTypeValidator
+	"consensus-full", // NodeTypeConsensusFull
+}
+
+// Generic Node Types (Infrastructure and alternative systems)
+
+// GenericNodeType represents other types of nodes (infrastructure, alternative consensus, etc.)
+type GenericNodeType int
+
+const (
+	// Alternative Consensus Engines
+	NodeTypeRollkit GenericNodeType = iota // Rollkit node (alternative consensus engine)
+
+	// Infrastructure Services
+	NodeTypeHermes // Hermes IBC relayer service
+)
+
+// String returns the string representation of the GenericNodeType
+func (n GenericNodeType) String() string {
+	return genericNodeTypeStrings[n]
+}
+
+var genericNodeTypeStrings = [...]string{
+	"rollkit",        // NodeTypeRollkit
+	"hermes-relayer", // NodeTypeHermes
+}
+
+// DA Node Types (Data Availability layer)
+
+// DANodeType represents Data Availability layer node types
+type DANodeType int
+
+const (
+	BridgeNode DANodeType = iota // Bridge node in DA network
+	LightNode                    // Light node in DA network
+	FullNode                     // Full node in DA network
+)
+
+// String returns the string representation of the DANodeType
+func (n DANodeType) String() string {
+	return daNodeTypeStrings[n]
+}
+
+var daNodeTypeStrings = [...]string{
+	"bridge", // BridgeNode
+	"light",  // LightNode
+	"full",   // FullNode
+}
+
+// Interface Compliance Checks
+var (
+	_ NodeType = ConsensusNodeType(0)
+	_ NodeType = GenericNodeType(0)
+	_ NodeType = DANodeType(0)
+)

--- a/framework/types/node.go
+++ b/framework/types/node.go
@@ -11,9 +11,11 @@ type NodeType interface {
 type ConsensusNodeType int
 
 const (
+	// Unspecified consensus node type (zero value)
+	ConsensusUnspecified ConsensusNodeType = iota // Unspecified consensus node type
 	// Celestia Chain Node Types (CometBFT consensus)
-	NodeTypeValidator     ConsensusNodeType = iota // Validator node in blockchain
-	NodeTypeConsensusFull                          // Full node in blockchain
+	NodeTypeValidator     // Validator node in blockchain
+	NodeTypeConsensusFull // Full node in blockchain
 )
 
 // String returns the string representation of the ConsensusNodeType
@@ -22,31 +24,9 @@ func (n ConsensusNodeType) String() string {
 }
 
 var consensusNodeTypeStrings = [...]string{
-	"validator",      // NodeTypeValidator
-	"consensus-full", // NodeTypeConsensusFull
-}
-
-// Generic Node Types (Infrastructure and alternative systems)
-
-// GenericNodeType represents other types of nodes (infrastructure, alternative consensus, etc.)
-type GenericNodeType int
-
-const (
-	// Alternative Consensus Engines
-	NodeTypeRollkit GenericNodeType = iota // Rollkit node (alternative consensus engine)
-
-	// Infrastructure Services
-	NodeTypeHermes // Hermes IBC relayer service
-)
-
-// String returns the string representation of the GenericNodeType
-func (n GenericNodeType) String() string {
-	return genericNodeTypeStrings[n]
-}
-
-var genericNodeTypeStrings = [...]string{
-	"rollkit",        // NodeTypeRollkit
-	"hermes-relayer", // NodeTypeHermes
+	"unspec", // ConsensusUnspecified
+	"val",    // NodeTypeValidator
+	"cfull",  // NodeTypeConsensusFull
 }
 
 // DA Node Types (Data Availability layer)
@@ -55,9 +35,11 @@ var genericNodeTypeStrings = [...]string{
 type DANodeType int
 
 const (
-	BridgeNode DANodeType = iota // Bridge node in DA network
-	LightNode                    // Light node in DA network
-	FullNode                     // Full node in DA network
+	// Unspecified DA node type (zero value)
+	DAUnspecified DANodeType = iota // Unspecified DA node type
+	BridgeNode                      // Bridge node in DA network
+	LightNode                       // Light node in DA network
+	FullNode                        // Full node in DA network
 )
 
 // String returns the string representation of the DANodeType
@@ -66,6 +48,7 @@ func (n DANodeType) String() string {
 }
 
 var daNodeTypeStrings = [...]string{
+	"unspec", // DAUnspecified
 	"bridge", // BridgeNode
 	"light",  // LightNode
 	"full",   // FullNode
@@ -73,7 +56,6 @@ var daNodeTypeStrings = [...]string{
 
 // Interface Compliance Checks
 var (
-	_ NodeType = ConsensusNodeType(0)
-	_ NodeType = GenericNodeType(0)
-	_ NodeType = DANodeType(0)
+	_ NodeType = ConsensusUnspecified
+	_ NodeType = DAUnspecified
 )

--- a/framework/types/node.go
+++ b/framework/types/node.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 // NodeType represents any node type that can be converted to a string
 type NodeType interface {
 	String() string
@@ -20,7 +22,10 @@ const (
 
 // String returns the string representation of the ConsensusNodeType
 func (n ConsensusNodeType) String() string {
-	return consensusNodeTypeStrings[n]
+	if int(n) >= 0 && int(n) < len(consensusNodeTypeStrings) {
+		return consensusNodeTypeStrings[n]
+	}
+	return fmt.Sprintf("ConsensusNodeType(%d)", int(n))
 }
 
 var consensusNodeTypeStrings = [...]string{
@@ -44,7 +49,10 @@ const (
 
 // String returns the string representation of the DANodeType
 func (n DANodeType) String() string {
-	return daNodeTypeStrings[n]
+	if int(n) >= 0 && int(n) < len(daNodeTypeStrings) {
+		return daNodeTypeStrings[n]
+	}
+	return fmt.Sprintf("DANodeType(%d)", int(n))
 }
 
 var daNodeTypeStrings = [...]string{


### PR DESCRIPTION
Closes #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified, strongly-typed node-type system and new relayer/rollup node types; node types expose enum stringifications.

* **Refactor**
  * Public APIs now accept/return typed node enums (replacing raw strings); node defaulting adjusted and legacy internal constants removed.

* **Chores**
  * Added memory-bank/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->