### PR TITLE
chore: make post inits additive

### DIFF
--- a/framework/docker/chain_builder.go
+++ b/framework/docker/chain_builder.go
@@ -142,7 +142,7 @@ type ChainBuilder struct {
 	dockerImage *container.Image
 	// additionalStartArgs are the default additional command-line arguments for all nodes in the chain (can be overridden per node)
 	additionalStartArgs []string
-	// postInits are the default post-initialization functionss for all nodes in the chain (can be overridden per node)
+	// postInits are the default post-initialization functions for all nodes in the chain (can be overridden per node)
 	postInits []func(ctx context.Context, node *ChainNode) error
 	// env are the default environment variables for all nodes in the chain (can be overridden per node)
 	env []string

--- a/framework/docker/chain_builder.go
+++ b/framework/docker/chain_builder.go
@@ -142,8 +142,8 @@ type ChainBuilder struct {
 	dockerImage *container.Image
 	// additionalStartArgs are the default additional command-line arguments for all nodes in the chain (can be overridden per node)
 	additionalStartArgs []string
-	// postInit are the default post-initialization functions for all nodes in the chain (can be overridden per node)
-	postInit []func(ctx context.Context, node *ChainNode) error
+	// postInits are the default post-initialization functionss for all nodes in the chain (can be overridden per node)
+	postInits []func(ctx context.Context, node *ChainNode) error
 	// env are the default environment variables for all nodes in the chain (can be overridden per node)
 	env []string
 	// faucetWallet is the wallet that should be used when broadcasting transactions when the sender doesn't matter
@@ -304,7 +304,7 @@ func (b *ChainBuilder) WithAdditionalStartArgs(args ...string) *ChainBuilder {
 
 // WithPostInit sets the default post init functions for all nodes in the chain
 func (b *ChainBuilder) WithPostInit(postInitFns ...func(ctx context.Context, node *ChainNode) error) *ChainBuilder {
-	b.postInit = postInitFns
+	b.postInits = append(b.postInits, postInitFns...)
 	return b
 }
 
@@ -348,7 +348,7 @@ func (b *ChainBuilder) getPostInit(nodeConfig ChainNodeConfig) []func(ctx contex
 		return nodeConfig.postInit
 	}
 	// use chain default post init functions (may be empty)
-	return b.postInit
+	return b.postInits
 }
 
 // getEnv returns the appropriate environment variables for a node, using node-specific override if available,
@@ -397,7 +397,7 @@ func (b *ChainBuilder) Build(ctx context.Context) (*Chain, error) {
 				CoinType:            b.coinType,
 				GasPrices:           b.gasPrices,
 				GasAdjustment:       b.gasAdjustment,
-				PostInit:            b.postInit,
+				PostInit:            b.postInits,
 				EncodingConfig:      b.encodingConfig,
 				AdditionalStartArgs: b.additionalStartArgs,
 				Env:                 b.env,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

multiple calls to WithPostInit was previously overriding the entire list, this made it so when you try and add on a new config, it would disable the api server as that is configured in the default post init.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support stacking multiple default post-initialization actions applied across all chain nodes, allowing additive setup routines.
  * Per-node post-initialization overrides still take precedence when defined.
  * Greater flexibility for configuring shared setup behavior across deployments.

* **Refactor**
  * Internal wiring updated to propagate the new multi-action default behavior through chain construction.

* **Chores**
  * Minor comment cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->