### PR TITLE
feat: add retry mechanism for busybox image pull

### DIFF
--- a/framework/docker/internal/busybox.go
+++ b/framework/docker/internal/busybox.go
@@ -49,7 +49,7 @@ func EnsureBusybox(ctx context.Context, cli *client.Client) error {
 	err = wait.ForCondition(ctx, 60*time.Second, 5*time.Second, func() (bool, error) {
 		rc, err := cli.ImagePull(ctx, BusyboxRef, dockerimagetypes.PullOptions{})
 		if err != nil {
-			return false, fmt.Errorf("pulling busybox image: %w", err)
+			return false, nil
 		}
 
 		_, _ = io.Copy(io.Discard, rc)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Sometimes due to network problems, docker cannot find the image, leading to unstable test.
Fix: https://github.com/celestiaorg/celestia-app/issues/5570
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic retry when downloading the BusyBox image, improving resilience against transient network or registry issues.

- Bug Fixes
  - Reduced flakiness during image pulls; operations that depend on BusyBox are less likely to fail intermittently.
  - More informative error surfaced if all retries are exhausted.

- Chores
  - Internal reliability improvements around image acquisition; behavior is unchanged when the image is already present. No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->