### PR TITLE
refactor: update to new evnode flag

### DIFF
--- a/framework/docker/evstack/node.go
+++ b/framework/docker/evstack/node.go
@@ -108,7 +108,7 @@ func (n *Node) Init(ctx context.Context, initArguments ...string) error {
 		cmd = append(cmd,
 			"--evnode.node.aggregator",
 			"--evnode.signer.passphrase="+n.cfg.AggregatorPassphrase, //nolint:gosec // used for testing only
-			"--evnode.signer.path="+signerPath)
+			"--evnode.signer.signer_path="+signerPath)
 	}
 
 	cmd = append(cmd, initArguments...)
@@ -152,7 +152,7 @@ func (n *Node) createEvstackContainer(ctx context.Context, additionalStartArgs .
 		startCmd = append(startCmd,
 			"--evnode.node.aggregator",
 			"--evnode.signer.passphrase="+n.cfg.AggregatorPassphrase, //nolint:gosec // used for testing only
-			"--evnode.signer.path="+signerPath)
+			"--evnode.signer.signer_path="+signerPath)
 	}
 
 	// add stored additional start args from the node configuration


### PR DESCRIPTION
ref: https://github.com/evstack/ev-node/pull/2637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Renamed the CLI flag for the aggregator signer path to --evnode.signer.signer_path.
  - Signer path still resolves from the node’s config directory and is supplied alongside the aggregator and passphrase options.
  - No behavioral or workflow changes beyond adopting the new flag name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->