### PR TITLE
chore: add mutex around port allocation

### DIFF
--- a/framework/docker/container/lifecycle.go
+++ b/framework/docker/container/lifecycle.go
@@ -129,6 +129,8 @@ func (c *Lifecycle) CreateContainer(
 func (c *Lifecycle) StartContainer(ctx context.Context) error {
 	// lock port allocation for the time between freeing the ports from the
 	// temporary listeners to the consumption of the ports by the container
+	internal.LockPortAssignment()
+	defer internal.UnlockPortAssignment()
 
 	c.preStartListeners.CloseAll()
 	c.preStartListeners = port.Listeners{}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview


ref https://github.com/celestiaorg/celestia-app/pull/5763/files#r2354549596

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforces exclusive port assignment during container startup to prevent transient “address already in use” errors.
  * Reduces race conditions when starting multiple containers concurrently, improving reliability and consistency of port bindings under load.
  * Users should experience fewer failed starts and less flakiness during rapid or parallel launches.
  * No changes to user-facing APIs or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->