### PR TITLE
feat: support for internal port configuration

### DIFF
--- a/framework/docker/cosmos/chain.go
+++ b/framework/docker/cosmos/chain.go
@@ -17,20 +17,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	dockerimagetypes "github.com/docker/docker/api/types/image"
-	"github.com/docker/go-connections/nat"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
 var _ types.Chain = &Chain{}
-
-var sentryPorts = nat.PortMap{
-	nat.Port(p2pPort):     {},
-	nat.Port(rpcPort):     {},
-	nat.Port(grpcPort):    {},
-	nat.Port(apiPort):     {},
-	nat.Port(privValPort): {},
-}
 
 type Chain struct {
 	t          *testing.T

--- a/framework/docker/internal/strings.go
+++ b/framework/docker/internal/strings.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"regexp"
+	"strings"
 )
 
 // CondenseHostName truncates the middle of the given name
@@ -29,4 +30,22 @@ var validContainerCharsRE = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
 // invalid characters too.
 func SanitizeContainerName(name string) string {
 	return validContainerCharsRE.ReplaceAllLiteralString(name, "_")
+}
+
+// ParseCommandLineArgs converts a slice of command line arguments into a map for easy lookup.
+// Arguments in the format "--key=value" are stored as key -> value.
+// Arguments without "=" are stored as key -> "" (empty string).
+func ParseCommandLineArgs(args []string) map[string]string {
+	result := make(map[string]string)
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--") {
+			arg = strings.TrimPrefix(arg, "--")
+			if parts := strings.SplitN(arg, "=", 2); len(parts) == 2 {
+				result[parts[0]] = parts[1]
+			} else {
+				result[arg] = ""
+			}
+		}
+	}
+	return result
 }

--- a/framework/docker/internal/strings.go
+++ b/framework/docker/internal/strings.go
@@ -34,18 +34,26 @@ func SanitizeContainerName(name string) string {
 
 // ParseCommandLineArgs converts a slice of command line arguments into a map for easy lookup.
 // Arguments in the format "--key=value" are stored as key -> value.
+// Arguments in the format "-key=value" are stored as key -> value.
 // Arguments without "=" are stored as key -> "" (empty string).
 func ParseCommandLineArgs(args []string) map[string]string {
 	result := make(map[string]string)
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "--") {
-			arg = strings.TrimPrefix(arg, "--")
-			if parts := strings.SplitN(arg, "=", 2); len(parts) == 2 {
-				result[parts[0]] = parts[1]
-			} else {
-				result[arg] = ""
-			}
+			parsePrefix(arg, "--", result)
+		} else if strings.HasPrefix(arg, "-") {
+			parsePrefix(arg, "-", result)
 		}
 	}
 	return result
+}
+
+// parsePrefix removes the given prefix from arg and splits it into key and value at the first "=".
+func parsePrefix(arg, prefix string, result map[string]string) {
+	arg = strings.TrimPrefix(arg, prefix)
+	if parts := strings.SplitN(arg, "=", 2); len(parts) == 2 {
+		result[parts[0]] = parts[1]
+	} else {
+		result[arg] = ""
+	}
 }

--- a/framework/docker/internal/strings_test.go
+++ b/framework/docker/internal/strings_test.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCommandLineArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected map[string]string
+	}{
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "single key-value pair",
+			args:     []string{"--rpc.laddr=tcp://0.0.0.0:26757"},
+			expected: map[string]string{"rpc.laddr": "tcp://0.0.0.0:26757"},
+		},
+		{
+			name:     "multiple key-value pairs",
+			args:     []string{"--rpc.laddr=tcp://0.0.0.0:26757", "--grpc.address=0.0.0.0:9090"},
+			expected: map[string]string{"rpc.laddr": "tcp://0.0.0.0:26757", "grpc.address": "0.0.0.0:9090"},
+		},
+		{
+			name:     "flag without value",
+			args:     []string{"--force-no-bbr"},
+			expected: map[string]string{"force-no-bbr": ""},
+		},
+		{
+			name:     "mixed flags and key-value pairs",
+			args:     []string{"--rpc.laddr=tcp://0.0.0.0:26757", "--force-no-bbr", "--timeout-commit=1s"},
+			expected: map[string]string{"rpc.laddr": "tcp://0.0.0.0:26757", "force-no-bbr": "", "timeout-commit": "1s"},
+		},
+		{
+			name:     "args without double dash are ignored",
+			args:     []string{"-rpc.laddr=tcp://0.0.0.0:26757", "start", "--force-no-bbr"},
+			expected: map[string]string{"force-no-bbr": ""},
+		},
+		{
+			name:     "value with equals sign",
+			args:     []string{"--config=key=value"},
+			expected: map[string]string{"config": "key=value"},
+		},
+		{
+			name:     "empty value",
+			args:     []string{"--rpc.laddr="},
+			expected: map[string]string{"rpc.laddr": ""},
+		},
+		{
+			name:     "complex values",
+			args:     []string{"--minimum-gas-prices=0.025utia", "--rpc.grpc_laddr=tcp://0.0.0.0:9098"},
+			expected: map[string]string{"minimum-gas-prices": "0.025utia", "rpc.grpc_laddr": "tcp://0.0.0.0:9098"},
+		},
+		{
+			name:     "all port configurations",
+			args:     []string{"--rpc.laddr=tcp://0.0.0.0:26757", "--grpc.address=0.0.0.0:9091", "--api.address=tcp://0.0.0.0:1318", "--p2p.laddr=tcp://0.0.0.0:26658"},
+			expected: map[string]string{"rpc.laddr": "tcp://0.0.0.0:26757", "grpc.address": "0.0.0.0:9091", "api.address": "tcp://0.0.0.0:1318", "p2p.laddr": "tcp://0.0.0.0:26658"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseCommandLineArgs(tt.args)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("ParseCommandLineArgs() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/framework/docker/internal/strings_test.go
+++ b/framework/docker/internal/strings_test.go
@@ -37,9 +37,9 @@ func TestParseCommandLineArgs(t *testing.T) {
 			expected: map[string]string{"rpc.laddr": "tcp://0.0.0.0:26757", "force-no-bbr": "", "timeout-commit": "1s"},
 		},
 		{
-			name:     "args without double dash are ignored",
+			name:     "args with dash are parsed",
 			args:     []string{"-rpc.laddr=tcp://0.0.0.0:26757", "start", "--force-no-bbr"},
-			expected: map[string]string{"force-no-bbr": ""},
+			expected: map[string]string{"rpc.laddr": "tcp://0.0.0.0:26757", "force-no-bbr": ""},
 		},
 		{
 			name:     "value with equals sign",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This issue popped up when working on the attester work cc @randygrok 

closes #123

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for custom RPC, GRPC, API, and P2P port configurations via startup arguments.
  - Internal ports are auto-derived from listen addresses, improving container port mapping reliability.
  - Network info now reflects configured internal ports accurately.

- **Tests**
  - Integration test verifying custom port configurations end-to-end.
  - Unit tests for command-line argument parsing covering flags, key-value pairs, and complex cases.

- **Chores**
  - Removed an unused dependency to streamline the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->