### PR TITLE
chore: fix port collision when concurrent container creation happens

### DIFF
--- a/framework/docker/port/port.go
+++ b/framework/docker/port/port.go
@@ -42,9 +42,6 @@ func OpenListener(port int) (*net.TCPListener, error) {
 // host and bind them to the container ports.
 // This is useful for cases where you want to find a random open port.
 func GenerateBindings(pairs nat.PortMap) (nat.PortMap, Listeners, error) {
-	mu.Lock()
-	defer mu.Unlock()
-
 	listeners := make(Listeners, 0)
 	bindings := make(nat.PortMap)
 

--- a/framework/docker/port/port.go
+++ b/framework/docker/port/port.go
@@ -22,6 +22,9 @@ func (l Listeners) CloseAll() {
 
 // OpenListener opens a listener on a port. Set to 0 to get a random port.
 func OpenListener(port int) (*net.TCPListener, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, err
@@ -61,7 +64,7 @@ func GenerateBindings(pairs nat.PortMap) (nat.PortMap, Listeners, error) {
 			return nil, nil, fmt.Errorf("failed to parse address: %s", listener.Addr().String())
 		}
 		portStr := parts[len(parts)-1]
-		
+
 		bindings[port] = []nat.PortBinding{
 			{
 				HostIP:   "127.0.0.1",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

It looks like the previous fix correctly handled the clearing of the preStartListeners when the container was started, and worked when a single node ran `GenerateBindings`, but when multiple nodes ran `GenerateBindings`, there was no protection within the `OpenListener` fn.

By moving the mutex into `OpenListener` instead it handles all such cases.

<img width="500" height="553" alt="image" src="https://github.com/user-attachments/assets/e1126021-28a1-4091-8eb9-ce35ffda3ddc" />



<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency safety when opening network listeners, reducing the risk of race conditions and intermittent port conflicts.
* **Performance**
  * Streamlined port binding workflow by removing unnecessary synchronization in non-critical paths, lowering contention under load.
* **Stability**
  * Enhances reliability during startup and high-concurrency scenarios, decreasing sporadic failures.
* **Style**
  * Minor formatting cleanups for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->