### PR TITLE
fix: ensure volumes can be rebound to new containers

### DIFF
--- a/framework/docker/node_volume_test.go
+++ b/framework/docker/node_volume_test.go
@@ -24,42 +24,47 @@ func TestNode_VolumeRebinding(t *testing.T) {
 		UIDGID:     "0:0",
 	}
 
-	node := container.NewNode(
-		testCfg.NetworkID,
-		testCfg.DockerClient,
-		testCfg.TestName,
-		image,
-		"/test",
-		0,
-		types.NodeTypeValidator,
-		logger,
-	)
-	node.SetContainerLifecycle(container.NewLifecycle(logger, testCfg.DockerClient, testCfg.TestName))
+	createNode := func() *container.Node {
+		node := container.NewNode(
+			testCfg.NetworkID,
+			testCfg.DockerClient,
+			testCfg.TestName,
+			image,
+			"/test",
+			0,
+			types.NodeTypeValidator,
+			logger,
+		)
+		node.SetContainerLifecycle(container.NewLifecycle(logger, testCfg.DockerClient, testCfg.TestName))
 
-	nodeName := testCfg.TestName + "-test-node-0"
+		nodeName := testCfg.TestName + "-test-node-0"
 
-	// create and setup volume
-	err := node.CreateAndSetupVolume(testCfg.Ctx, nodeName)
-	require.NoError(t, err)
-	require.NotEmpty(t, node.VolumeName)
+		err := node.CreateAndSetupVolume(testCfg.Ctx, nodeName)
+		require.NoError(t, err)
+		require.NotEmpty(t, node.VolumeName)
 
-	err = node.CreateContainer(
-		testCfg.Ctx,
-		t.Name(),
-		testCfg.NetworkID,
-		image,
-		nil,
-		"",
-		[]string{node.GetVolumeName(nodeName) + ":/test"},
-		nil,
-		internal.CondenseHostName(nodeName),
-		nil,
-		[]string{"sleep", "5000"},
-		nil,
-	)
-	require.NoError(t, err)
+		// create a container that will just sleep forever so the test can exec into it.
+		err = node.CreateContainer(
+			testCfg.Ctx,
+			t.Name(),
+			testCfg.NetworkID,
+			image,
+			nil,
+			"",
+			[]string{node.GetVolumeName(nodeName) + ":/test"},
+			nil,
+			internal.CondenseHostName(nodeName),
+			[]string{"sleep", "infinity"},
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		return node
+	}
 
-	err = node.StartContainer(testCfg.Ctx)
+	node := createNode()
+
+	err := node.StartContainer(testCfg.Ctx)
 	require.NoError(t, err)
 
 	volumeName1 := node.VolumeName
@@ -83,26 +88,12 @@ func TestNode_VolumeRebinding(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testContent2, readContent2)
 
+	// remove the code but preserver the volumes, this allows us to create a new node on the same volume.
 	err = node.Remove(testCfg.Ctx, types.WithPreserveVolumes())
 	require.NoError(t, err)
 
-	// re-creating exact same node.
-	node = container.NewNode(
-		testCfg.NetworkID,
-		testCfg.DockerClient,
-		testCfg.TestName,
-		image,
-		"/test",
-		0,
-		types.NodeTypeValidator,
-		logger,
-	)
-	node.SetContainerLifecycle(container.NewLifecycle(logger, testCfg.DockerClient, testCfg.TestName))
-
-	// create and setup volume again - should bind to existing volume
-	err = node.CreateAndSetupVolume(testCfg.Ctx, nodeName)
-	require.NoError(t, err)
-	require.NotEmpty(t, node.VolumeName)
+	// re-creating exact same node, which should bind to the same volume.
+	node = createNode()
 
 	volumeName2 := node.VolumeName
 

--- a/framework/docker/node_volume_test.go
+++ b/framework/docker/node_volume_test.go
@@ -1,0 +1,120 @@
+package docker
+
+import (
+	"github.com/celestiaorg/tastora/framework/docker/container"
+	"github.com/celestiaorg/tastora/framework/docker/internal"
+	"github.com/celestiaorg/tastora/framework/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"testing"
+)
+
+func TestNode_VolumeRebinding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping due to short mode")
+	}
+	t.Parallel()
+
+	testCfg := setupDockerTest(t)
+
+	logger := zaptest.NewLogger(t)
+	image := container.Image{
+		Repository: "alpine",
+		Version:    "latest",
+		UIDGID:     "0:0",
+	}
+
+	node := container.NewNode(
+		testCfg.NetworkID,
+		testCfg.DockerClient,
+		testCfg.TestName,
+		image,
+		"/test",
+		0,
+		types.NodeTypeValidator,
+		logger,
+	)
+	node.SetContainerLifecycle(container.NewLifecycle(logger, testCfg.DockerClient, testCfg.TestName))
+
+	nodeName := testCfg.TestName + "-test-node-0"
+
+	// create and setup volume
+	err := node.CreateAndSetupVolume(testCfg.Ctx, nodeName)
+	require.NoError(t, err)
+	require.NotEmpty(t, node.VolumeName)
+
+	err = node.CreateContainer(
+		testCfg.Ctx,
+		t.Name(),
+		testCfg.NetworkID,
+		image,
+		nil,
+		"",
+		[]string{node.GetVolumeName(nodeName) + ":/test"},
+		nil,
+		internal.CondenseHostName(nodeName),
+		nil,
+		[]string{"sleep", "5000"},
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = node.StartContainer(testCfg.Ctx)
+	require.NoError(t, err)
+
+	volumeName1 := node.VolumeName
+
+	// write test files to volume
+	testContent1 := []byte("test file 1 content")
+	testContent2 := []byte("test file 2 content")
+
+	err = node.WriteFile(testCfg.Ctx, "test1.txt", testContent1)
+	require.NoError(t, err)
+
+	err = node.WriteFile(testCfg.Ctx, "test2.txt", testContent2)
+	require.NoError(t, err)
+
+	// verify files were written
+	readContent1, err := node.ReadFile(testCfg.Ctx, "test1.txt")
+	require.NoError(t, err)
+	require.Equal(t, testContent1, readContent1)
+
+	readContent2, err := node.ReadFile(testCfg.Ctx, "test2.txt")
+	require.NoError(t, err)
+	require.Equal(t, testContent2, readContent2)
+
+	err = node.Remove(testCfg.Ctx, types.WithPreserveVolumes())
+	require.NoError(t, err)
+
+	// re-creating exact same node.
+	node = container.NewNode(
+		testCfg.NetworkID,
+		testCfg.DockerClient,
+		testCfg.TestName,
+		image,
+		"/test",
+		0,
+		types.NodeTypeValidator,
+		logger,
+	)
+	node.SetContainerLifecycle(container.NewLifecycle(logger, testCfg.DockerClient, testCfg.TestName))
+
+	// create and setup volume again - should bind to existing volume
+	err = node.CreateAndSetupVolume(testCfg.Ctx, nodeName)
+	require.NoError(t, err)
+	require.NotEmpty(t, node.VolumeName)
+
+	volumeName2 := node.VolumeName
+
+	// verify that the same volume was used
+	require.Equal(t, volumeName1, volumeName2, "should reuse the same volume")
+
+	// verify that files are still present
+	readContent1, err = node.ReadFile(testCfg.Ctx, "test1.txt")
+	require.NoError(t, err)
+	require.Equal(t, testContent1, readContent1)
+
+	readContent2, err = node.ReadFile(testCfg.Ctx, "test2.txt")
+	require.NoError(t, err)
+	require.Equal(t, testContent2, readContent2)
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The current volume creation logic would never pass a name and would allow docker to choose a volume name. This meant that even if you want to re-bind to an existing one, you couldn't. This PR updates the container.Node type to allow you pass a deterministic volume name (based on node name and test name)

I also added a test which writes files to a volume, deletes the container while preserving the volume and verifies the contents are still there with the new container.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
