### PR TITLE
fix: preserve volumes on container removal option

### DIFF
--- a/framework/docker/container/node.go
+++ b/framework/docker/container/node.go
@@ -92,6 +92,10 @@ func (n *Node) RemoveContainer(ctx context.Context, opts ...types.RemoveOption) 
 	if err != nil {
 		return err
 	}
+	removeOpts := ApplyRemoveOptions(opts...)
+	if !removeOpts.RemoveVolumes {
+		return nil
+	}
 	return n.ContainerLifecycle.RemoveVolumes(ctx, n.TestName)
 }
 


### PR DESCRIPTION
Quick PR to fix this issue: https://github.com/celestiaorg/tastora/pull/136#discussion_r2410804943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Container removal now supports configurable options, including the ability to skip volume deletion.
  - Default behavior removes containers forcefully and includes associated volumes.
  - Improved handling of already-removed or missing containers for a smoother experience.

- Refactor
  - Centralized application of removal options to ensure consistent behavior across removal workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->