### PR TITLE
Fix cel-key interactive prompts

### DIFF
--- a/framework/docker/dataavailability/node.go
+++ b/framework/docker/dataavailability/node.go
@@ -217,7 +217,7 @@ func (n *Node) initNode(ctx context.Context, chainID string, env []string) error
 	}
 
 	// note: my_celes_key is the default key name for the da node.
-	cmd := []string{n.cfg.Bin, n.nodeType.String(), "init", "--p2p.network", chainID, "--keyring.keyname", "my-key", "--node.store", n.HomeDir()}
+	cmd := []string{n.cfg.Bin, n.nodeType.String(), "init", "--p2p.network", chainID, "--keyring.keyname", "my-key", "--node.store", n.HomeDir(), "--keyring.backend", "test"}
 	_, _, err := n.Exec(ctx, n.Logger, cmd, env)
 	return err
 }
@@ -225,7 +225,8 @@ func (n *Node) initNode(ctx context.Context, chainID string, env []string) error
 // createWallet creates a wallet for use on this node. Creating one explicitly
 // gives us access to the address for use in tests.
 func (n *Node) createWallet(ctx context.Context) error {
-	cmd := []string{"cel-key", "add", "my-key", "--node.type", n.nodeType.String(), "--keyring-dir", path.Join(n.HomeDir(), "keys"), "--output", "json"}
+	// Try using test keyring backend which should be non-interactive and persistent
+	cmd := []string{"cel-key", "add", "my-key", "--node.type", n.nodeType.String(), "--keyring-dir", path.Join(n.HomeDir(), "keys"), "--output", "json", "--no-backup", "--keyring-backend", "test"}
 	_, stderr, err := n.Exec(ctx, n.Logger, cmd, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create wallet: %w", err)


### PR DESCRIPTION
## Problem
The tastora framework was failing during key creation with EOF errors because `cel-key add` was expecting interactive input for backup confirmation and keyring backend selection. This caused test failures with:

```
Error: EOF Usage: keys add <name> [flags]
```


## Solution
Added non-interactive flags to the `cel-key add` command:
- `--no-backup`: Prevents interactive backup confirmation prompt
- `--keyring-backend test`: Uses test keyring backend (non-interactive, persistent)

## Changes
- Modified `cel-key add` command in tastora framework to include `--no-backup` and `--keyring-backend test` flags
- This ensures key creation is fully non-interactive and suitable for automated testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DA node initialization and wallet creation now use a persistent keyring backend, enabling fully non-interactive setup.
  * Backup prompts during wallet creation are removed, improving compatibility with automated deployments and scripts.
  * Keys are stored persistently, providing consistent access across restarts without manual intervention.
  * Existing workflows continue to function, but users who relied on interactive prompts may notice a smoother, prompt-free experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->