### PR TITLE
chore: enable evm-single to be restarted

### DIFF
--- a/framework/docker/evstack/evmsingle/builder.go
+++ b/framework/docker/evstack/evmsingle/builder.go
@@ -90,7 +90,7 @@ func (b *ChainBuilder) WithNodes(cfgs ...NodeConfig) *ChainBuilder {
 	return b
 }
 
-// Build constructs a Chain with nodes created and volumes initialized (not started)
+// Build constructs a Chain with nodes created and volumes initialized (not isInitialized)
 func (b *ChainBuilder) Build(ctx context.Context) (*Chain, error) {
 	cfg := Config{
 		Logger:              b.logger,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

When working on an upgrade test using evm-single, I noticed the logic for re-starting was not correct.

in the test I remove the container preserving volumes, but then it fails on re-start as the containers don't exist. What we actually just need is to bypass the init phase on restart.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
