### PR TITLE
feat: migrate evstack health checks to HTTP /health/ready endpoint

### DIFF
--- a/framework/docker/evmsingle_with_reth_test.go
+++ b/framework/docker/evmsingle_with_reth_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -189,10 +188,9 @@ func TestEvmSingle_WithReth(t *testing.T) {
 	require.NotEmpty(t, eni.External.Ports.RPC)
 
 	// Health check via evnode health endpoint
-	healthURL := fmt.Sprintf("http://0.0.0.0:%s/evnode.v1.HealthService/Livez", eni.External.Ports.RPC)
+	healthURL := fmt.Sprintf("http://0.0.0.0:%s/health/ready", eni.External.Ports.RPC)
 	require.Eventually(t, func() bool {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, healthURL, bytes.NewBufferString("{}"))
-		req.Header.Set("Content-Type", "application/json")
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return false

--- a/framework/docker/evstack/evmsingle/node.go
+++ b/framework/docker/evstack/evmsingle/node.go
@@ -1,7 +1,6 @@
 package evmsingle
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -199,11 +198,10 @@ func (n *Node) createNodeContainer(ctx context.Context) error {
 	return n.CreateContainer(ctx, n.TestName, n.NetworkID, n.Image, usingPorts, "", n.Bind(), nil, n.HostName(), cmd, n.cfg.Env, []string{})
 }
 
-// waitForSelfReady runs `evm-single net-info` inside the container until it succeeds,
-// indicating the internal RPC (127.0.0.1:7331) is serving.
+// waitForSelfReady polls the HTTP health endpoint until the node is ready
 func (n *Node) waitForSelfReady(ctx context.Context) error {
 	deadline := time.Now().Add(120 * time.Second)
-	httpURL := fmt.Sprintf("http://0.0.0.0:%s/evnode.v1.HealthService/Livez", n.external.RPC)
+	httpURL := fmt.Sprintf("http://0.0.0.0:%s/health/ready", n.external.RPC)
 	for {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("evm-single health not ready within timeout at %s", httpURL)
@@ -220,8 +218,7 @@ func (n *Node) waitForSelfReady(ctx context.Context) error {
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, httpURL, bytes.NewBufferString("{}"))
-		req.Header.Set("Content-Type", "application/json")
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, httpURL, nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err == nil {
 			_ = resp.Body.Close()

--- a/framework/docker/evstack/node.go
+++ b/framework/docker/evstack/node.go
@@ -1,7 +1,6 @@
 package evstack
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -258,7 +257,7 @@ func (n *Node) GetNetworkInfo(ctx context.Context) (types.NetworkInfo, error) {
 
 // waitForNodeReady polls the health endpoint until the node is ready or timeout is reached
 func (n *Node) waitForNodeReady(ctx context.Context, timeout time.Duration) error {
-	healthURL := fmt.Sprintf("http://0.0.0.0:%s/evnode.v1.HealthService/Livez", n.externalPorts.RPC)
+	healthURL := fmt.Sprintf("http://0.0.0.0:%s/health/ready", n.externalPorts.RPC)
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	timeoutCh := time.After(timeout)
@@ -280,14 +279,13 @@ func (n *Node) waitForNodeReady(ctx context.Context, timeout time.Duration) erro
 	}
 }
 
-// isNodeHealthy checks if the node health endpoint returns 200
+// isNodeHealthy checks if the node health endpoint returns 200 with READY response
 func (n *Node) isNodeHealthy(client *http.Client, healthURL string) bool {
-	req, err := http.NewRequest("POST", healthURL, bytes.NewBufferString("{}"))
+	req, err := http.NewRequest("GET", healthURL, nil)
 	if err != nil {
 		n.logger().Debug("failed to create health check request", zap.Error(err))
 		return false
 	}
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Update evstack health checks to use the new HTTP /health/ready endpoint
instead of the gRPC /evnode.v1.HealthService/Livez endpoint.

Changes:
- Replace gRPC endpoint with /health/ready HTTP endpoint
- Update health check method from POST to GET
- Continue using RPC port (7331) where HTTP endpoints are served
- Remove unused bytes import

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


Related to https://github.com/evstack/ev-node/pull/2800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check mechanism to use standard HTTP readiness endpoint instead of custom RPC endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->