### PR TITLE
chore: enable configuration of binary for evm single

### DIFF
--- a/framework/docker/evstack/evmsingle/builder.go
+++ b/framework/docker/evstack/evmsingle/builder.go
@@ -18,6 +18,7 @@ type ChainBuilder struct {
 	dockerClient types.TastoraDockerClient
 	networkID    string
 	image        container.Image
+	bin          string
 	env          []string
 	addlArgs     []string
 	nodes        []NodeConfig
@@ -33,7 +34,8 @@ func NewChainBuilderWithTestName(t *testing.T, testName string) *ChainBuilder {
 		WithT(t).
 		WithTestName(testName).
 		WithLogger(zaptest.NewLogger(t)).
-		WithImage(DefaultImage())
+		WithImage(DefaultImage()).
+		WithBinary(DefaultBinary())
 }
 
 func (b *ChainBuilder) WithT(t *testing.T) *ChainBuilder {
@@ -63,6 +65,11 @@ func (b *ChainBuilder) WithDockerNetworkID(id string) *ChainBuilder {
 
 func (b *ChainBuilder) WithImage(img container.Image) *ChainBuilder {
 	b.image = img
+	return b
+}
+
+func (b *ChainBuilder) WithBinary(bin string) *ChainBuilder {
+	b.bin = bin
 	return b
 }
 
@@ -97,7 +104,7 @@ func (b *ChainBuilder) Build(ctx context.Context) (*Chain, error) {
 		DockerClient:        b.dockerClient,
 		DockerNetworkID:     b.networkID,
 		Image:               b.image,
-		Bin:                 "evm-single",
+		Bin:                 b.bin,
 		Env:                 b.env,
 		AdditionalStartArgs: b.addlArgs,
 	}

--- a/framework/docker/evstack/evmsingle/config.go
+++ b/framework/docker/evstack/evmsingle/config.go
@@ -27,3 +27,8 @@ type Config struct {
 func DefaultImage() container.Image {
 	return container.Image{Repository: "ghcr.io/evstack/ev-node-evm-single", Version: "main"}
 }
+
+// DefaultBinary returns the default binary name for ev-node-evm-single.
+func DefaultBinary() string {
+	return "evm-single"
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The binary changed from evm-single to evm, this PR makes it configurable.

We can leave the default as the old one to not break any existing tests. This can be bumped in the future.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Introduced configurable binary selection for EVM single chain builder, enabling dynamic specification of binaries during chain construction and initialization processes. This enhancement replaces previously hard-coded values, offering greater flexibility in chain building configurations while maintaining full backward compatibility with existing defaults and standard initialization workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->