### PR TITLE
fix: lock sha256 hyperlane-init docker image tag

### DIFF
--- a/framework/docker/hyperlane/hyperlane_config.go
+++ b/framework/docker/hyperlane/hyperlane_config.go
@@ -20,7 +20,7 @@ type Config struct {
 // DefaultDeployerImage returns the default hyperlane CLI image
 // TODO: replace this with an image that just has the hyperlane cli, not using the hyperlane-init image.
 func DefaultDeployerImage() container.Image {
-	return container.Image{Repository: "ghcr.io/celestiaorg/hyperlane-init", Version: "latest", UIDGID: "1000:1000"}
+	return container.Image{Repository: "ghcr.io/celestiaorg/hyperlane-init@sha256", Version: "04d570e31e8e459a8e7aa90d81bfe28df513201b98d027e37bed1bc861a2bbb1", UIDGID: "1000:1000"}
 }
 
 func DefaultForwardRelayerImage() container.Image {


### PR DESCRIPTION
## Overview

Ensure a compatible `hyperlane-init` deployer image is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hyperlane container image to use a specific pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->