### PR TITLE
feat: add WithBlockWaitTimeout to ChainBuilder

### DIFF
--- a/framework/docker/cosmos/chain.go
+++ b/framework/docker/cosmos/chain.go
@@ -50,6 +50,9 @@ type Chain struct {
 	started bool
 	// skipInit indicates whether to skip initialization when starting
 	skipInit bool
+	// blockWaitTimeout is the timeout for waiting for blocks after starting the chain.
+	// If zero, defaults to 120 seconds.
+	blockWaitTimeout time.Duration
 }
 
 func (c *Chain) GetRelayerConfig() types.ChainRelayerConfig {
@@ -331,8 +334,11 @@ func (c *Chain) startAndInitializeNodes(ctx context.Context) error {
 	}
 
 	// Wait for blocks before considering the chains "started"
-	// Use a longer timeout for block waiting to handle slow chain startup
-	blockWaitCtx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	blockWaitTimeout := c.blockWaitTimeout
+	if blockWaitTimeout == 0 {
+		blockWaitTimeout = 120 * time.Second
+	}
+	blockWaitCtx, cancel := context.WithTimeout(context.Background(), blockWaitTimeout)
 	defer cancel()
 	if err := wait.ForBlocks(blockWaitCtx, 2, c.GetNode()); err != nil {
 		return err

--- a/framework/docker/cosmos/chain.go
+++ b/framework/docker/cosmos/chain.go
@@ -338,7 +338,7 @@ func (c *Chain) startAndInitializeNodes(ctx context.Context) error {
 	if blockWaitTimeout == 0 {
 		blockWaitTimeout = 120 * time.Second
 	}
-	blockWaitCtx, cancel := context.WithTimeout(context.Background(), blockWaitTimeout)
+	blockWaitCtx, cancel := context.WithTimeout(ctx, blockWaitTimeout)
 	defer cancel()
 	if err := wait.ForBlocks(blockWaitCtx, 2, c.GetNode()); err != nil {
 		return err

--- a/framework/docker/cosmos/chain_builder.go
+++ b/framework/docker/cosmos/chain_builder.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/celestiaorg/tastora/framework/docker/container"
 	"github.com/celestiaorg/tastora/framework/types"
@@ -154,6 +155,9 @@ type ChainBuilder struct {
 	additionalExposedPorts []string
 	// skipInit indicates whether to skip node initialization on start (useful when reusing volumes)
 	skipInit bool
+	// blockWaitTimeout is the timeout for waiting for blocks after starting the chain.
+	// If zero, defaults to 120 seconds.
+	blockWaitTimeout time.Duration
 }
 
 // NewChainBuilder initializes and returns a new ChainBuilder with default values for testing purposes.
@@ -341,6 +345,14 @@ func (b *ChainBuilder) WithSkipInit(skip bool) *ChainBuilder {
 	return b
 }
 
+// WithBlockWaitTimeout sets the timeout for waiting for blocks after starting
+// the chain. If not set, defaults to 120 seconds. Use a longer timeout for
+// chains that need extra time to start (e.g. state sync nodes).
+func (b *ChainBuilder) WithBlockWaitTimeout(timeout time.Duration) *ChainBuilder {
+	b.blockWaitTimeout = timeout
+	return b
+}
+
 // getImage returns the appropriate Docker image for a node, using node-specific override if available,
 // otherwise falling back to the chain's default image
 func (b *ChainBuilder) getImage(nodeConfig ChainNodeConfig) container.Image {
@@ -434,8 +446,9 @@ func (b *ChainBuilder) Build(ctx context.Context) (*Chain, error) {
 		FullNodes:    fullNodes,
 		cdc:          cdc,
 		log:          b.logger,
-		faucetWallet: b.faucetWallet,
-		skipInit:     b.skipInit,
+		faucetWallet:     b.faucetWallet,
+		skipInit:         b.skipInit,
+		blockWaitTimeout: b.blockWaitTimeout,
 	}
 
 	return chain, nil


### PR DESCRIPTION
## Summary
- Add configurable `WithBlockWaitTimeout` option to `ChainBuilder` so callers can override the hardcoded 120-second block wait timeout in `Chain.Start()`
- The default behavior is unchanged (120s) when `WithBlockWaitTimeout` is not called
- This is needed for state sync nodes that need extra time to sync before receiving blocks
- Use the caller's context (instead of `context.Background()`) for the block wait timeout so it respects the caller's cancellation and deadline

Closes celestiaorg/celestia-app#7017

## Test plan
- [ ] Verify existing tests pass (default 120s timeout unchanged)
- [ ] Verify `WithBlockWaitTimeout` is usable from celestia-app's sync-to-tip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable block wait timeout for blockchain operations (defaults to 120 seconds).
  * Block operations now properly respect timeout and cancellation requests from callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->