### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chatton @mojtaba-esk @tty47
+* @chatton @tty47


### PR DESCRIPTION
Remove Mojtaba. The CODEOWNERs should probably be updated to the devops team + Cian


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->