### PR TITLE
ci: add merge_group trigger to workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Add `merge_group` trigger to lint and test workflows so CI runs when PRs enter the merge queue
- Without this trigger, the merge queue removes PRs due to "no response for status checks"

unblocks merge for celestiaorg/tastora#190

## Test plan

- [ ] Verify lint and test workflows trigger on the merge group event
- [ ] Add PR #190 to the merge queue and confirm it merges successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflows to run linting and testing checks during GitHub merge queue processing, in addition to existing push and pull request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->